### PR TITLE
fix: update database connection logic for Vercel and local environments

### DIFF
--- a/apps/assassin/prisma.config.ts
+++ b/apps/assassin/prisma.config.ts
@@ -4,6 +4,6 @@ import { defineConfig, env } from "prisma/config";
 export default defineConfig({
   schema: "prisma/schema.prisma",
   datasource: {
-    url: env("DATABASE_URL"),
+    url: process.env.VERCEL === "1" ? env("DATABASE_URL") : env("DIRECT_URL"),
   },
 });

--- a/apps/assassin/src/libs/prisma/client.ts
+++ b/apps/assassin/src/libs/prisma/client.ts
@@ -1,12 +1,34 @@
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "../../generated/prisma/client";
 
-const connectionString = `${process.env.DATABASE_URL}`;
+function getConnectionString() {
+  // ✅ Vercel 배포 환경
+  if (process.env.VERCEL === "1") {
+    if (!process.env.DATABASE_URL) {
+      throw new Error("DATABASE_URL is required on Vercel");
+    }
+    return process.env.DATABASE_URL; // transaction pooler
+  }
 
-const adapter = new PrismaPg({ connectionString });
+  // ✅ 로컬 개발 환경
+  if (!process.env.DIRECT_URL) {
+    throw new Error("DIRECT_URL is required locally");
+  }
+  return process.env.DIRECT_URL; // session pooler
+}
+
+const connectionString = getConnectionString();
+
+const adapter = new PrismaPg({
+  connectionString,
+});
 
 const globalForPrisma = globalThis as unknown as { prisma: PrismaClient };
 
-export const prisma = globalForPrisma.prisma || new PrismaClient({ adapter });
+export const prisma =
+  globalForPrisma.prisma ||
+  new PrismaClient({
+    adapter,
+  });
 
 if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;


### PR DESCRIPTION
⏺ ## 환경별 Database URL 설정

  ### 변경 사항

  **Prisma 7 설정**
  - 환경별 connection string 분리
  - VERCEL 환경 변수 기반 datasource 설정

  **로컬 개발 환경**
  - `DIRECT_URL` 사용 (5432 포트)
  - Session pooler로 빠른 개발 속도

  **Vercel 배포 환경**
  - `DATABASE_URL` 사용 (6543 포트)
  - Transaction pooler로 serverless 최적화

  **Schema 개선**
  - Season 모델에 `@map` 적용 (camelCase ↔ snake_case 변환)
  - 불필요한 `description` 필드 제거