### PR TITLE
feat: 이슈 기반 feature 브랜치 생성 및 자동 PR 생성 기능 추가

### DIFF
--- a/apps/ymm/src/claude/runner.ts
+++ b/apps/ymm/src/claude/runner.ts
@@ -21,6 +21,7 @@ type RunOptions = {
   sessionId?: string          // 이어갈 세션 ID (없으면 새 세션)
   onSessionId?: (id: string) => void  // 세션 ID 획득 시 콜백
   onDone?: () => void         // 프로세스 종료 시 콜백
+  onSuccess?: () => Promise<void>     // 작업 성공 시 콜백
 }
 
 export function runClaudeCode(
@@ -28,7 +29,7 @@ export function runClaudeCode(
   message: Message,
   processingMsg: Message,
   tempFiles: string[],
-  { sessionId, onSessionId, onDone }: RunOptions = {}
+  { sessionId, onSessionId, onDone, onSuccess }: RunOptions = {}
 ) {
   const start = Date.now()
   const discordLogger = createDiscordLogger(message.channel as { send: (content: string) => Promise<unknown> })
@@ -69,6 +70,7 @@ export function runClaudeCode(
       toolStats,
       onDecisionCount: (n) => { decisionCount = n },
       onSessionId,
+      onSuccess,
     })
   )
 
@@ -114,6 +116,7 @@ type StreamContext = {
   toolStats: Map<string, number>
   onDecisionCount: (n: number) => void
   onSessionId?: (id: string) => void
+  onSuccess?: () => Promise<void>
 }
 
 function handleStreamLine(line: string, ctx: StreamContext) {
@@ -204,6 +207,10 @@ function handleStreamLine(line: string, ctx: StreamContext) {
         ctx.discordLogger.forceFlush()
         const finalText = res.result?.trim() ? truncate(res.result, 1800) : '✅ 작업이 완료되었습니다.'
         ctx.processingMsg.edit(finalText).catch(() => {})
+        ctx.onSuccess?.().catch((err: Error) => {
+          ctx.discordLogger.log(`❌ PR 생성 실패: ${err.message}`)
+          ctx.discordLogger.forceFlush()
+        })
       } else {
         console.log(`\n${ts()} ${c.bold}${c.red}══ 작업 실패 (${elapsed}s) ══${c.reset}`)
         ctx.discordLogger.log(`❌ 작업 실패 (${elapsed}s)`)

--- a/apps/ymm/src/discord/bot.ts
+++ b/apps/ymm/src/discord/bot.ts
@@ -1,10 +1,11 @@
 import { Client, GatewayIntentBits, Message } from 'discord.js'
+import { execSync } from 'child_process'
 import { DISCORD_TOKEN, PROJECT_ROOT, ALLOWED_CHANNEL_IDS } from '../config.js'
 import { downloadAttachments, buildPrompt, cleanup } from './attachments.js'
 import { getSession, setSession, clearSession } from './sessionStore.js'
 import { killProcess, getProcess, setProcess, clearProcess } from './processStore.js'
 import { runClaudeCode } from '../claude/runner.js'
-import { fetchIssue, buildIssuePrompt } from '../github/client.js'
+import { fetchIssue, buildIssuePrompt, createPR } from '../github/client.js'
 
 const COMMANDS = [
   { name: '!done',    desc: '현재 세션 종료 (다음 메시지부터 새 작업으로 시작)' },
@@ -86,8 +87,21 @@ client.on('messageCreate', async (message: Message) => {
       return
     }
 
+    // feature 브랜치 생성
+    const branchName = `feat/issue-${issue.number}`
+    try {
+      execSync(`git -C "${PROJECT_ROOT}" checkout -b ${branchName}`, { stdio: 'pipe' })
+    } catch {
+      try {
+        execSync(`git -C "${PROJECT_ROOT}" checkout ${branchName}`, { stdio: 'pipe' })
+      } catch (err) {
+        await fetchingMsg.edit(`❌ 브랜치 생성 실패: ${(err as Error).message}`)
+        return
+      }
+    }
+
     const issuePrompt = buildIssuePrompt(issue)
-    await fetchingMsg.edit(`📋 **Issue #${issue.number}: ${issue.title}**\n> 작업을 시작합니다...`)
+    await fetchingMsg.edit(`📋 **Issue #${issue.number}: ${issue.title}**\n> \`${branchName}\` 브랜치에서 작업을 시작합니다...`)
 
     const processingMsg = fetchingMsg
     const sessionId = getSession(message.channelId)
@@ -95,6 +109,14 @@ client.on('messageCreate', async (message: Message) => {
       sessionId,
       onSessionId: (id) => setSession(message.channelId, id),
       onDone: () => clearProcess(message.channelId),
+      onSuccess: async () => {
+        try {
+          const pr = await createPR(issue, branchName)
+          await message.reply(`🎉 PR이 생성되었습니다! **#${pr.number}**\n${pr.url}`)
+        } catch (err) {
+          await message.reply(`❌ PR 자동 생성 실패: ${(err as Error).message}`)
+        }
+      },
     })
     setProcess(message.channelId, child)
     return

--- a/apps/ymm/src/github/client.ts
+++ b/apps/ymm/src/github/client.ts
@@ -9,6 +9,11 @@ export interface GitHubIssue {
   url: string
 }
 
+export interface GitHubPR {
+  number: number
+  url: string
+}
+
 export async function fetchIssue(issueNumber: number): Promise<GitHubIssue> {
   if (!GITHUB_TOKEN || !GITHUB_REPO) {
     throw new Error('GITHUB_TOKEN 또는 GITHUB_REPO가 설정되지 않았습니다.')
@@ -42,6 +47,38 @@ export async function fetchIssue(issueNumber: number): Promise<GitHubIssue> {
     state: data.state,
     url: data.html_url,
   }
+}
+
+export async function createPR(issue: GitHubIssue, branchName: string, baseBranch = 'dev'): Promise<GitHubPR> {
+  if (!GITHUB_TOKEN || !GITHUB_REPO) {
+    throw new Error('GITHUB_TOKEN 또는 GITHUB_REPO가 설정되지 않았습니다.')
+  }
+
+  const body = [`closes #${issue.number}`, '', issue.body ?? ''].join('\n').trim()
+
+  const res = await fetch(`https://api.github.com/repos/${GITHUB_REPO}/pulls`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${GITHUB_TOKEN}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      title: issue.title,
+      body,
+      head: branchName,
+      base: baseBranch,
+    }),
+  })
+
+  if (!res.ok) {
+    const errorBody = await res.text()
+    throw new Error(`PR 생성 실패: ${res.status} ${res.statusText} - ${errorBody}`)
+  }
+
+  const data = await res.json() as { number: number; html_url: string }
+  return { number: data.number, url: data.html_url }
 }
 
 export function buildIssuePrompt(issue: GitHubIssue): string {


### PR DESCRIPTION
closes #90

## 변경 사항

- `github/client.ts`: `createPR` 함수 추가 - GitHub API를 통해 PR 자동 생성
- `claude/runner.ts`: `onSuccess` 콜백 추가 - 작업 성공 시 실행
- `discord/bot.ts`: `#이슈번호` 명령 시 `feat/issue-{number}` 브랜치 자동 생성 후, 작업 완료 시 PR 자동 생성 및 Discord에 PR URL 알림