### PR TITLE
feat: Discord 채널을 역할별로 분리 (명령/결과/로그)

### DIFF
--- a/apps/ymm/.env.example
+++ b/apps/ymm/.env.example
@@ -1,8 +1,10 @@
 # Discord Bot Token (Discord Developer Portal에서 발급)
 DISCORD_TOKEN=your_discord_bot_token_here
 
-# 봇이 메시지를 받을 채널 ID (쉼표로 여러 개 지정 가능)
-ALLOWED_CHANNEL_IDS=123456789,987654321
+# 채널 ID (용도별)
+DISCORD_COMMAND_ID=12345    # 명령/질의응답 채널 (봇이 이 채널에서만 메시지를 수신)
+DISCORD_RESULT_ID=112345    # 작업 완료 / PR 생성 결과 채널
+DISCORD_LOG_ID=12345        # 모든 실행 로그 채널
 
 # 프로젝트 루트 경로 (기본값: 자동 감지)
 # PROJECT_ROOT=/absolute/path/to/SUNNYSIDE-CRUISE

--- a/apps/ymm/src/claude/runner.ts
+++ b/apps/ymm/src/claude/runner.ts
@@ -17,11 +17,15 @@ const COMMIT_INSTRUCTIONS = `
 - 커밋 전 git status로 변경 파일을 확인하고, 관련 파일만 stage하세요.
 `
 
+type SendFn = (content: string) => Promise<unknown>
+
 type RunOptions = {
-  sessionId?: string          // 이어갈 세션 ID (없으면 새 세션)
+  sessionId?: string                  // 이어갈 세션 ID (없으면 새 세션)
   onSessionId?: (id: string) => void  // 세션 ID 획득 시 콜백
-  onDone?: () => void         // 프로세스 종료 시 콜백
+  onDone?: () => void                 // 프로세스 종료 시 콜백
   onSuccess?: () => Promise<void>     // 작업 성공 시 콜백
+  logChannel?: { send: SendFn }       // 로그 전용 채널 (DISCORD_LOG_ID)
+  resultChannel?: { send: SendFn }    // 결과 전용 채널 (DISCORD_RESULT_ID)
 }
 
 export function runClaudeCode(
@@ -29,10 +33,13 @@ export function runClaudeCode(
   message: Message,
   processingMsg: Message,
   tempFiles: string[],
-  { sessionId, onSessionId, onDone, onSuccess }: RunOptions = {}
+  { sessionId, onSessionId, onDone, onSuccess, logChannel, resultChannel }: RunOptions = {}
 ) {
   const start = Date.now()
-  const discordLogger = createDiscordLogger(message.channel as { send: (content: string) => Promise<unknown> })
+  // 로그는 logChannel 우선, 없으면 command 채널로 fallback
+  const discordLogger = createDiscordLogger(
+    logChannel ?? (message.channel as { send: (content: string) => Promise<unknown> })
+  )
 
   const promptPreview = prompt.slice(0, 100) + (prompt.length > 100 ? '...' : '')
   const sessionLabel = sessionId ? ` (세션 재개: ${sessionId.slice(0, 8)}...)` : ' (새 세션)'
@@ -63,6 +70,7 @@ export function runClaudeCode(
     handleStreamLine(line, {
       discordLogger,
       processingMsg,
+      resultChannel,
       start,
       decisionCount,
       toolIdToNum,
@@ -109,6 +117,7 @@ const PROGRESS_INTERVAL = 5  // N번 툴 호출마다 Discord에 진행상황 �
 type StreamContext = {
   discordLogger: ReturnType<typeof createDiscordLogger>
   processingMsg: Message
+  resultChannel?: { send: (content: string) => Promise<unknown> }
   start: number
   decisionCount: number
   toolIdToNum: Map<string, number>
@@ -203,10 +212,15 @@ function handleStreamLine(line: string, ctx: StreamContext) {
         const statsStr = ctx.toolStats.size > 0
           ? `\n도구 사용: ${[...ctx.toolStats.entries()].map(([k, v]) => `${k}×${v}`).join(', ')}`
           : ''
+        // 로그 채널: 완료 요약
         ctx.discordLogger.log(`✅ 작업 완료 (${elapsed}s${cost}${turns})${statsStr}`)
         ctx.discordLogger.forceFlush()
+        // 커맨드 채널: 진행 메시지를 "완료" 표시로 업데이트
+        ctx.processingMsg.edit('✅ 작업이 완료되었습니다.').catch(() => {})
+        // 결과 채널: 최종 결과 전송
         const finalText = res.result?.trim() ? truncate(res.result, 1800) : '✅ 작업이 완료되었습니다.'
-        ctx.processingMsg.edit(finalText).catch(() => {})
+        const resultTarget = ctx.resultChannel ?? (ctx.processingMsg.channel as { send: (content: string) => Promise<unknown> })
+        resultTarget.send(finalText).catch(() => {})
         ctx.onSuccess?.().catch((err: Error) => {
           ctx.discordLogger.log(`❌ PR 생성 실패: ${err.message}`)
           ctx.discordLogger.forceFlush()
@@ -215,7 +229,11 @@ function handleStreamLine(line: string, ctx: StreamContext) {
         console.log(`\n${ts()} ${c.bold}${c.red}══ 작업 실패 (${elapsed}s) ══${c.reset}`)
         ctx.discordLogger.log(`❌ 작업 실패 (${elapsed}s)`)
         ctx.discordLogger.forceFlush()
+        // 커맨드 채널: 진행 메시지 업데이트
         ctx.processingMsg.edit('❌ 작업이 실패했습니다.').catch(() => {})
+        // 결과 채널: 실패 알림
+        const resultTarget = ctx.resultChannel ?? (ctx.processingMsg.channel as { send: (content: string) => Promise<unknown> })
+        resultTarget.send(`❌ 작업이 실패했습니다. (${elapsed}s)`).catch(() => {})
       }
       break
     }

--- a/apps/ymm/src/config.ts
+++ b/apps/ymm/src/config.ts
@@ -7,9 +7,11 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 export const DISCORD_TOKEN = process.env.DISCORD_TOKEN
 export const PROJECT_ROOT =
   process.env.PROJECT_ROOT ?? path.resolve(__dirname, '../../..')
-export const ALLOWED_CHANNEL_IDS = process.env.ALLOWED_CHANNEL_IDS
-  ? process.env.ALLOWED_CHANNEL_IDS.split(',').map((id) => id.trim())
-  : []
+
+// 채널별 ID
+export const DISCORD_COMMAND_ID = process.env.DISCORD_COMMAND_ID ?? ''  // 명령/질의응답 채널
+export const DISCORD_RESULT_ID  = process.env.DISCORD_RESULT_ID  ?? ''  // 작업 완료 / PR 결과 채널
+export const DISCORD_LOG_ID     = process.env.DISCORD_LOG_ID     ?? ''  // 모든 로그 채널
 
 export const GITHUB_TOKEN = process.env.GITHUB_TOKEN
 export const GITHUB_REPO = process.env.GITHUB_REPO
@@ -17,4 +19,7 @@ export const GITHUB_REPO = process.env.GITHUB_REPO
 if (!DISCORD_TOKEN) {
   console.error('DISCORD_TOKEN이 설정되지 않았습니다. .env 파일을 확인하세요.')
   process.exit(1)
+}
+if (!DISCORD_COMMAND_ID || !DISCORD_RESULT_ID || !DISCORD_LOG_ID) {
+  console.warn('⚠️  DISCORD_COMMAND_ID / DISCORD_RESULT_ID / DISCORD_LOG_ID 중 하나 이상이 설정되지 않았습니다.')
 }

--- a/apps/ymm/src/discord/bot.ts
+++ b/apps/ymm/src/discord/bot.ts
@@ -1,6 +1,6 @@
-import { Client, GatewayIntentBits, Message } from 'discord.js'
+import { Client, GatewayIntentBits, Message, TextChannel } from 'discord.js'
 import { execSync } from 'child_process'
-import { DISCORD_TOKEN, PROJECT_ROOT, ALLOWED_CHANNEL_IDS } from '../config.js'
+import { DISCORD_TOKEN, PROJECT_ROOT, DISCORD_COMMAND_ID, DISCORD_RESULT_ID, DISCORD_LOG_ID } from '../config.js'
 import { downloadAttachments, buildPrompt, cleanup } from './attachments.js'
 import { getSession, setSession, clearSession } from './sessionStore.js'
 import { killProcess, getProcess, setProcess, clearProcess } from './processStore.js'
@@ -17,6 +17,13 @@ const COMMANDS = [
 
 const ISSUE_PATTERN = /^#(\d+)$/
 
+/** 채널 ID로 TextChannel을 가져옵니다. 없으면 undefined를 반환합니다. */
+function getTextChannel(id: string): TextChannel | undefined {
+  if (!id) return undefined
+  const ch = client.channels.cache.get(id)
+  return ch instanceof TextChannel ? ch : undefined
+}
+
 export const client = new Client({
   intents: [
     GatewayIntentBits.Guilds,
@@ -28,12 +35,15 @@ export const client = new Client({
 client.once('ready', () => {
   console.log(`봇 로그인 완료: ${client.user?.tag}`)
   console.log(`프로젝트 루트: ${PROJECT_ROOT}`)
-  console.log(`허용된 채널: ${ALLOWED_CHANNEL_IDS.length > 0 ? ALLOWED_CHANNEL_IDS.join(', ') : '모든 채널'}`)
+  console.log(`명령 채널: ${DISCORD_COMMAND_ID || '(미설정)'}`)
+  console.log(`결과 채널: ${DISCORD_RESULT_ID || '(미설정)'}`)
+  console.log(`로그 채널:  ${DISCORD_LOG_ID || '(미설정)'}`)
 })
 
 client.on('messageCreate', async (message: Message) => {
   if (message.author.bot) return
-  if (ALLOWED_CHANNEL_IDS.length > 0 && !ALLOWED_CHANNEL_IDS.includes(message.channelId)) return
+  // 명령 채널이 설정된 경우 해당 채널에서만 수신
+  if (DISCORD_COMMAND_ID && message.channelId !== DISCORD_COMMAND_ID) return
 
   const text = message.content.trim()
 
@@ -105,16 +115,21 @@ client.on('messageCreate', async (message: Message) => {
 
     const processingMsg = fetchingMsg
     const sessionId = getSession(message.channelId)
+    const logChannel = getTextChannel(DISCORD_LOG_ID)
+    const resultChannel = getTextChannel(DISCORD_RESULT_ID)
     const child = runClaudeCode(issuePrompt, message, processingMsg, [], {
       sessionId,
       onSessionId: (id) => setSession(message.channelId, id),
       onDone: () => clearProcess(message.channelId),
+      logChannel,
+      resultChannel,
       onSuccess: async () => {
+        const target = resultChannel ?? message.channel as TextChannel
         try {
           const pr = await createPR(issue, branchName)
-          await message.reply(`🎉 PR이 생성되었습니다! **#${pr.number}**\n${pr.url}`)
+          await target.send(`🎉 PR이 생성되었습니다! **#${pr.number}**\n${pr.url}`)
         } catch (err) {
-          await message.reply(`❌ PR 자동 생성 실패: ${(err as Error).message}`)
+          await target.send(`❌ PR 자동 생성 실패: ${(err as Error).message}`)
         }
       },
     })
@@ -137,6 +152,8 @@ client.on('messageCreate', async (message: Message) => {
       sessionId,
       onSessionId: (id) => setSession(message.channelId, id),
       onDone: () => clearProcess(message.channelId),
+      logChannel: getTextChannel(DISCORD_LOG_ID),
+      resultChannel: getTextChannel(DISCORD_RESULT_ID),
     })
     setProcess(message.channelId, child)
   } catch (err) {


### PR DESCRIPTION
## Summary

- `DISCORD_COMMAND_ID` 채널에서만 사용자 명령 수신 및 Q&A 응답
- `DISCORD_RESULT_ID` 채널로 작업 완료/실패 결과 및 PR 생성 알림 전송
- `DISCORD_LOG_ID` 채널로 모든 실행 로그(툴 사용, 진행 요약, 오류 등) 분리

## 변경 파일

- `config.ts`: `DISCORD_COMMAND_ID`, `DISCORD_RESULT_ID`, `DISCORD_LOG_ID` 환경변수 추가
- `bot.ts`: COMMAND_ID 채널 전용 수신 필터, `getTextChannel()` 헬퍼, PR 메시지 → result 채널
- `runner.ts`: `logChannel` / `resultChannel` 옵션 추가, 채널별 메시지 라우팅
- `.env.example`: 채널 ID 설명 주석 추가

## Test plan

- [ ] `.env`에 `DISCORD_COMMAND_ID`, `DISCORD_RESULT_ID`, `DISCORD_LOG_ID` 설정
- [ ] 명령 채널에서 일반 프롬프트 전송 → 로그 채널에 로그, 결과 채널에 완료 메시지 확인
- [ ] `#이슈번호` 입력 → PR 생성 메시지가 결과 채널에 전송되는지 확인
- [ ] 다른 채널에서 메시지 전송 시 봇이 무시하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)