### PR TITLE
feat: command 채널 유저 인터랙션 및 로그 상세화

### DIFF
--- a/apps/ymm/src/claude/runner.ts
+++ b/apps/ymm/src/claude/runner.ts
@@ -20,12 +20,13 @@ const COMMIT_INSTRUCTIONS = `
 type SendFn = (content: string) => Promise<unknown>
 
 type RunOptions = {
-  sessionId?: string                  // 이어갈 세션 ID (없으면 새 세션)
-  onSessionId?: (id: string) => void  // 세션 ID 획득 시 콜백
-  onDone?: () => void                 // 프로세스 종료 시 콜백
-  onSuccess?: () => Promise<void>     // 작업 성공 시 콜백
-  logChannel?: { send: SendFn }       // 로그 전용 채널 (DISCORD_LOG_ID)
-  resultChannel?: { send: SendFn }    // 결과 전용 채널 (DISCORD_RESULT_ID)
+  sessionId?: string                   // 이어갈 세션 ID (없으면 새 세션)
+  onSessionId?: (id: string) => void   // 세션 ID 획득 시 콜백
+  onDone?: () => void                  // 프로세스 종료 시 콜백
+  onSuccess?: () => Promise<void>      // 작업 성공 시 콜백
+  logChannel?: { send: SendFn }        // 로그 전용 채널 (DISCORD_LOG_ID)
+  resultChannel?: { send: SendFn }     // 결과 전용 채널 (DISCORD_RESULT_ID)
+  commandChannel?: { send: SendFn }    // 명령/질의응답 채널 — 유저 확인/의사결정 필요 시 사용
 }
 
 export function runClaudeCode(
@@ -33,7 +34,7 @@ export function runClaudeCode(
   message: Message,
   processingMsg: Message,
   tempFiles: string[],
-  { sessionId, onSessionId, onDone, onSuccess, logChannel, resultChannel }: RunOptions = {}
+  { sessionId, onSessionId, onDone, onSuccess, logChannel, resultChannel, commandChannel }: RunOptions = {}
 ) {
   const start = Date.now()
   // 로그는 logChannel 우선, 없으면 command 채널로 fallback
@@ -71,6 +72,7 @@ export function runClaudeCode(
       discordLogger,
       processingMsg,
       resultChannel,
+      commandChannel,
       start,
       decisionCount,
       toolIdToNum,
@@ -86,6 +88,7 @@ export function runClaudeCode(
     const text = chunk.toString().trim()
     if (text) {
       console.error(`${ts()} ${c.red}[stderr]${c.reset} ${text}`)
+      discordLogger.log(`⚠️ [stderr] ${text.slice(0, 300)}`)
     }
   })
 
@@ -112,12 +115,11 @@ export function runClaudeCode(
   return child
 }
 
-const PROGRESS_INTERVAL = 5  // N번 툴 호출마다 Discord에 진행상황 전송
-
 type StreamContext = {
   discordLogger: ReturnType<typeof createDiscordLogger>
   processingMsg: Message
   resultChannel?: { send: (content: string) => Promise<unknown> }
+  commandChannel?: { send: (content: string) => Promise<unknown> }
   start: number
   decisionCount: number
   toolIdToNum: Map<string, number>
@@ -142,6 +144,7 @@ function handleStreamLine(line: string, ctx: StreamContext) {
       const sid = (event as { session_id?: string }).session_id
       if (sid) {
         console.log(`${ts()} ${c.gray}세션: ${sid}${c.reset}`)
+        ctx.discordLogger.log(`🔑 세션 ID: ${sid.slice(0, 8)}...`)
         ctx.onSessionId?.(sid)
       }
       break
@@ -155,11 +158,19 @@ function handleStreamLine(line: string, ctx: StreamContext) {
 
       if (reasoning) {
         if (toolBlocks.length > 0) {
+          // 도구 사용과 함께 나온 판단 근거 → 로그 채널에 전송 (축약)
           const truncated = reasoning.slice(0, 300) + (reasoning.length > 300 ? '...' : '')
           console.log(`\n${ts()} ${c.blue}[판단 근거]${c.reset} ${truncated}`)
+          ctx.discordLogger.log(`🤔 [판단] ${truncated}`)
         } else {
+          // 도구 없이 나온 텍스트 → 유저 확인/의사결정 필요 → command 채널로 전송
           console.log(`\n${ts()} ${c.blue}[Claude]${c.reset} ${reasoning}`)
-          ctx.discordLogger.log(`💬 ${reasoning}`)
+          const target = ctx.commandChannel
+          if (target) {
+            target.send(`💬 **Claude**\n${truncate(reasoning, 1800)}`).catch(() => {})
+          } else {
+            ctx.discordLogger.log(`💬 ${reasoning}`)
+          }
         }
       }
 
@@ -171,12 +182,8 @@ function handleStreamLine(line: string, ctx: StreamContext) {
         ctx.toolStats.set(block.name!, (ctx.toolStats.get(block.name!) ?? 0) + 1)
         const inputStr = formatToolInput(block.name!, block.input as Record<string, unknown>)
         console.log(`${ts()} ${c.yellow}${c.bold}[결정 #${ctx.decisionCount}]${c.reset} ${c.yellow}${block.name}${c.reset}\n  ${c.cyan}${inputStr}${c.reset}`)
-
-        if (ctx.decisionCount % PROGRESS_INTERVAL === 0) {
-          const elapsed = ((Date.now() - ctx.start) / 1000).toFixed(0)
-          const statsStr = [...ctx.toolStats.entries()].map(([k, v]) => `${k}×${v}`).join(', ')
-          ctx.discordLogger.log(`🔄 작업 중... (${elapsed}s | ${statsStr})`)
-        }
+        // 모든 tool call을 로그 채널에 전송 (이전: 5번마다)
+        ctx.discordLogger.log(`🔧 [#${ctx.decisionCount}] ${block.name!}: ${inputStr}`)
       }
       break
     }
@@ -191,8 +198,13 @@ function handleStreamLine(line: string, ctx: StreamContext) {
         const summary = summarizeToolResult(name, block.content)
         console.log(`${ts()} ${c.green}[결과 #${num ?? '?'}]${c.reset} ${name} → ${summary}`)
 
+        const cleanSummary = stripAnsi(summary)
         if (summary.includes('실패') || summary.includes('error')) {
-          ctx.discordLogger.log(`⚠️ ${name} 오류: ${stripAnsi(summary)}`)
+          // 오류는 항상 로그
+          ctx.discordLogger.log(`❌ [#${num ?? '?'}] ${name} 오류: ${cleanSummary}`)
+        } else {
+          // 정상 결과도 로그에 기록
+          ctx.discordLogger.log(`✔️ [#${num ?? '?'}] ${name}: ${cleanSummary}`)
         }
       }
       break

--- a/apps/ymm/src/discord/bot.ts
+++ b/apps/ymm/src/discord/bot.ts
@@ -126,12 +126,14 @@ client.on('messageCreate', async (message: Message) => {
     const sessionId = getSession(message.channelId)
     const logChannel = getTextChannel(DISCORD_LOG_ID)
     const resultChannel = getTextChannel(DISCORD_RESULT_ID)
+    const commandChannel = getTextChannel(DISCORD_COMMAND_ID)
     const child = runClaudeCode(issuePrompt, message, processingMsg, [], {
       sessionId,
       onSessionId: (id) => setSession(message.channelId, id),
       onDone: () => clearProcess(message.channelId),
       logChannel,
       resultChannel,
+      commandChannel,
       onSuccess: async () => {
         const target = resultChannel ?? message.channel as TextChannel
         try {
@@ -163,6 +165,7 @@ client.on('messageCreate', async (message: Message) => {
       onDone: () => clearProcess(message.channelId),
       logChannel: getTextChannel(DISCORD_LOG_ID),
       resultChannel: getTextChannel(DISCORD_RESULT_ID),
+      commandChannel: getTextChannel(DISCORD_COMMAND_ID),
     })
     setProcess(message.channelId, child)
   } catch (err) {


### PR DESCRIPTION
## Summary

- **command 채널 유저 인터랙션**: Claude가 tool 없이 텍스트만 보낼 때 (유저 확인/의사결정이 필요한 경우) log 채널 대신 command 채널로 직접 전송. 유저가 command 채널에서 응답하면 세션 ID를 통해 대화가 자연스럽게 이어짐
- **로그 상세화**: 매 tool 호출마다 로그 전송 (이전: 5번마다), tool 결과(성공/실패 모두), 판단 근거, stderr 출력, 세션 ID 획득 시점을 log 채널에 기록
- **bot.ts**: 일반 메시지 및 이슈 기반 작업 모두 `commandChannel` 전달

## 채널별 역할 정리

| 채널 | 전송 내용 |
|------|----------|
| **command** | Claude의 질문/확인 요청 (tool 없는 텍스트 응답), 작업 완료/실패 상태 |
| **log** | 모든 tool 호출 상세 (매번), tool 결과, 판단 근거, stderr, 세션 ID, 완료 요약 |
| **result** | 최종 작업 결과, PR 링크 |

## Test plan

- [ ] command 채널에 작업 요청 → Claude가 파일 수정 중 로그 채널에 매 tool 호출 기록 확인
- [ ] Claude가 유저에게 질문해야 하는 상황 → command 채널에 메시지 전송 확인
- [ ] command 채널에서 응답 시 세션 연속성으로 대화 이어짐 확인
- [ ] `#이슈번호` 작업 시 동일하게 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)