### PR TITLE
revert(assassin): dfa3285에서 잘못 포함된 assassin 변경사항 제거

### DIFF
--- a/apps/assassin/src/components/player/constants.ts
+++ b/apps/assassin/src/components/player/constants.ts
@@ -2,8 +2,7 @@ import type { Instrument } from "@/features/player/schema";
 
 export const INSTRUMENT_LABELS: Record<Instrument, string> = {
   VOCAL: "보컬",
-  LEAD_GUITAR: "리드기타",
-  RHYTHM_GUITAR: "리듬기타",
+  GUITAR: "기타",
   DRUM: "드럼",
   BASS: "베이스",
   KEYBOARD: "키보드",
@@ -12,10 +11,8 @@ export const INSTRUMENT_LABELS: Record<Instrument, string> = {
 export const INSTRUMENT_COLORS: Record<Instrument, string> = {
   VOCAL:
     "bg-blue-100 text-blue-700 hover:bg-blue-200 border-blue-200 dark:bg-blue-900/30 dark:text-blue-300 dark:border-blue-700/30 dark:hover:bg-blue-900/50",
-  LEAD_GUITAR:
+  GUITAR:
     "bg-orange-100 text-orange-700 hover:bg-orange-200 border-orange-200 dark:bg-orange-900/30 dark:text-orange-300 dark:border-orange-700/30 dark:hover:bg-orange-900/50",
-  RHYTHM_GUITAR:
-    "bg-amber-100 text-amber-700 hover:bg-amber-200 border-amber-200 dark:bg-amber-900/30 dark:text-amber-300 dark:border-amber-700/30 dark:hover:bg-amber-900/50",
   DRUM:
     "bg-red-100 text-red-700 hover:bg-red-200 border-red-200 dark:bg-red-900/30 dark:text-red-300 dark:border-red-700/30 dark:hover:bg-red-900/50",
   BASS:

--- a/apps/assassin/src/features/player/schema.ts
+++ b/apps/assassin/src/features/player/schema.ts
@@ -1,14 +1,7 @@
 import { dbSchema } from "@libs/prisma/types";
 import * as z from "zod";
 
-const instrumentEnum = z.enum([
-  "VOCAL",
-  "LEAD_GUITAR",
-  "RHYTHM_GUITAR",
-  "DRUM",
-  "BASS",
-  "KEYBOARD",
-]);
+const instrumentEnum = z.enum(["VOCAL", "GUITAR", "DRUM", "BASS", "KEYBOARD"]);
 
 // DB에 저장할 때 입력 스키마
 export const createPlayerSchema = z.object({


### PR DESCRIPTION
## Summary
- `dfa3285` 커밋에는 ymm 작업(claude code 명령어 리스트)과 무관한 assassin 변경사항이 포함되어 있었음
- `GUITAR` → `LEAD_GUITAR` / `RHYTHM_GUITAR` 분리 작업을 되돌림
- ymm 관련 변경사항(`apps/ymm/src/discord/bot.ts`)은 이미 dev에 존재하므로 별도 작업 불필요

## Changed Files
- `apps/assassin/src/features/player/schema.ts`: enum을 `GUITAR` 단일로 복구
- `apps/assassin/src/components/player/constants.ts`: label/color 매핑을 `GUITAR`로 복구

🤖 Generated with [Claude Code](https://claude.com/claude-code)