### PR TITLE
[#99] feat(ymm): !cost 명령어 추가 및 명령어 목록 표시명 개선

### DIFF
--- a/apps/ymm/src/discord/bot.ts
+++ b/apps/ymm/src/discord/bot.ts
@@ -11,7 +11,7 @@ const COMMANDS = [
   { name: '!done',    desc: '현재 세션 종료 (다음 메시지부터 새 작업으로 시작)' },
   { name: '!stop',    desc: '실행 중인 작업 강제 종료 + 세션 초기화' },
   { name: '!session', desc: '현재 활성 세션 ID 확인' },
-  { name: '!cost',    desc: 'Claude Code 세션의 토큰 사용량 확인 (/cost)' },
+  { name: '!cost',    desc: 'Claude Code 세션의 토큰 사용량 확인' },
   { name: '#숫자',    desc: 'GitHub 이슈 번호로 Claude Code 작업 시작 (예: #42)' },
   { name: '/help',    desc: '명령어 목록 보기' },
 ]
@@ -72,12 +72,12 @@ client.on('messageCreate', async (message: Message) => {
     return
   }
 
-  // !cost — Claude Code /cost 출력
+  // !cost — Claude Code /context 출력
   if (text === '!cost') {
     const sid = getSession(message.channelId)
     try {
       const resumeFlag = sid ? `--resume ${sid} ` : ''
-      const output = execSync(`claude ${resumeFlag}-p "/cost"`, {
+      const output = execSync(`claude ${resumeFlag}-p "/context"`, {
         cwd: PROJECT_ROOT,
         encoding: 'utf8',
         timeout: 15000,


### PR DESCRIPTION
## 완료 조건

- [x] `!cost` 입력 시 마지막 작업의 비용(`$USD`)과 턴 수를 Discord에 응답한다
- [x] 완료된 작업이 없을 경우 적절한 안내 메시지를 반환한다
- [x] `/help` 명령어 목록에서 `#42` 대신 `#숫자` 로 표시된다

## 변경 내용

- `runner.ts`: `onCost` 콜백 옵션 추가, `result` 이벤트 성공 시 호출
- `bot.ts`: 채널별 `lastCostStore`에 비용 저장, `!cost` 명령어 핸들러 추가, COMMANDS 표시명 수정

closes #99