### PR TITLE
[#107] assassin 네비게이션에 YouTube 채널 바로가기 링크 추가

### DIFF
--- a/apps/assassin/src/components/navigation/AppNav.tsx
+++ b/apps/assassin/src/components/navigation/AppNav.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { Youtube } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { LogoutButton } from "./LogoutButton";
 import ProfileButton from "./ProfileButton";
 import { TabNav } from "./TabNav";
@@ -9,6 +11,17 @@ export function AppNav() {
     <div className="flex items-center justify-between border-b border-slate-200 dark:border-slate-800 mb-4 flex-shrink-0">
       <TabNav />
       <div className="flex items-center gap-1 pb-1">
+        <Button
+          variant="ghost"
+          size="sm"
+          asChild
+          className="text-slate-600 hover:text-slate-900 hover:bg-slate-100 dark:text-slate-400 dark:hover:text-slate-50 dark:hover:bg-slate-700"
+        >
+          <a href="https://youtube.com/@dnab-dnab?si=iX2ulzqGQYl_4Xm9" target="_blank" rel="noopener noreferrer">
+            <Youtube className="h-4 w-4" />
+            <span className="hidden sm:inline ml-2">YouTube</span>
+          </a>
+        </Button>
         <ProfileButton />
         <LogoutButton />
       </div>


### PR DESCRIPTION
## 변경 사항
`apps/assassin/src/components/navigation/AppNav.tsx`에 YouTube 채널 바로가기 버튼 추가

## 완료 조건 체크리스트
- [x] 네비게이션 우측에 YouTube 아이콘 버튼이 표시된다
- [x] 버튼 클릭 시 `https://youtube.com/@dnab-dnab?si=iX2ulzqGQYl_4Xm9` 채널로 이동한다 (새 탭)
- [x] 모바일: 아이콘만 표시, sm(640px) 이상: "YouTube" 텍스트 함께 표시 (반응형)
- [x] 다크모드 지원 (기존 버튼 스타일과 동일)

closes #107