### PR TITLE
[#115] ymm: GitHub workflow를 봇이 직접 수행하도록 분리

### DIFF
--- a/apps/ymm/src/claude/runner.ts
+++ b/apps/ymm/src/claude/runner.ts
@@ -7,6 +7,28 @@ import { createDiscordLogger } from '../discord/discordLogger.js'
 import { cleanup } from '../discord/attachments.js'
 import { PROJECT_ROOT } from '../config.js'
 
+const WORKFLOW_RULES = `[WORKFLOW RULES]
+
+당신은 코드 수정 전담 워커입니다. 다음 규칙을 반드시 따르세요.
+
+작업 시작 전:
+1. CLAUDE.md 파일을 읽고 프로젝트 규칙을 파악한다.
+2. 작업 계획을 먼저 작성하고 요약해서 출력한다.
+3. 계획이 완료되기 전에는 코드를 수정하지 않는다.
+
+작업 중:
+- 코드 수정과 commit 생성만 담당한다.
+- dev checkout, 브랜치 생성, PR 생성은 수행하지 않는다. (봇이 담당)
+- 이슈에 명시된 파일 범위만 수정한다.
+
+작업 완료 후:
+- 변경된 파일을 commit한다. (conventional commit 형식, 한국어)
+- commit 후 작업 완료를 알린다.
+
+---
+
+`
+
 const COMMIT_INSTRUCTIONS = `
 
 ---
@@ -48,7 +70,7 @@ export function runClaudeCode(
   console.log(`${ts()} ${c.cyan}프롬프트:${c.reset} "${promptPreview}"`)
   discordLogger.log(`\n══ 작업 시작${sessionLabel} ══\n프롬프트: "${promptPreview}"`)
 
-  const fullPrompt = prompt + COMMIT_INSTRUCTIONS
+  const fullPrompt = WORKFLOW_RULES + prompt + COMMIT_INSTRUCTIONS
 
   const args = sessionId
     ? ['--resume', sessionId, '-p', fullPrompt]

--- a/apps/ymm/src/discord/bot.ts
+++ b/apps/ymm/src/discord/bot.ts
@@ -163,6 +163,14 @@ client.on('messageCreate', async (message: Message) => {
       commandChannel,
       onSuccess: async () => {
         const target = resultChannel ?? message.channel as TextChannel
+        // 빌드 확인
+        try {
+          execSync('pnpm --filter ymm build', { cwd: PROJECT_ROOT, stdio: 'pipe' })
+        } catch (err) {
+          await target.send(`❌ 빌드 실패로 PR 생성을 건너뜁니다.\n\`\`\`\n${(err as Error).message.slice(0, 500)}\n\`\`\``)
+          return
+        }
+        // PR 생성
         try {
           const pr = await createPR(issue, branchName)
           await target.send(`🎉 PR이 생성되었습니다! **#${pr.number}**\n${pr.url}`)


### PR DESCRIPTION
## 변경 사항

Claude가 GitHub workflow(dev checkout, 브랜치 생성, PR 생성)를 직접 수행하던 구조를 봇이 담당하도록 분리합니다.

## 변경 내용

### `runner.ts` — WORKFLOW_RULES 단순화
- Claude의 역할을 코드 수정 + commit으로 한정
- dev checkout, 브랜치 생성, PR 생성 지시 제거
- 봇이 담당하는 작업임을 명시

### `bot.ts` — onSuccess 빌드 확인 추가
- PR 생성 전 `pnpm --filter ymm build` 실행
- 빌드 실패 시 PR 생성 중단 및 Discord 알림

## 완료 조건
- [x] WORKFLOW_RULES에서 GitHub workflow 지시 제거 — Claude는 코드+커밋만 담당
- [x] `onSuccess`에서 빌드 확인 후 PR 생성
- [x] 빌드 실패 시 PR 생성 건너뜀
- [x] 빌드 성공 확인

closes #115