### PR TITLE
[#125] .claude/agents/domain-reviewer 에이전트 추가

### DIFF
--- a/.claude/agents/domain-reviewer.md
+++ b/.claude/agents/domain-reviewer.md
@@ -34,21 +34,6 @@ disallowedTools: Write, Edit
     If these files are readable, load them first. They are the source of truth for what "correct" looks like in this project.
   </Reference_Skills>
 
-  <Layer_Architecture_Rules>
-    The assassin app uses a strict layered architecture under `apps/assassin/src/features/<featureName>/`.
-    Each layer has exactly one responsibility. Cross-layer violations are HIGH severity issues.
-
-    | Layer | File | Allowed | Forbidden |
-    |---|---|---|---|
-    | Schema | `schema.ts` | Zod schemas, `z.infer` types | Business logic, DB calls |
-    | Repository | `repository.ts` | Prisma queries only, default export object | Business logic, Supabase direct calls, named exports as primary API |
-    | Service | `service.ts` | Business logic, `safeParse` validation | Direct Prisma calls, direct Supabase calls |
-    | Actions | `actions.ts` | `"use server"`, `getCurrentUser()`, `revalidatePath()` | Accepting `userId` from client, missing auth on write operations |
-    | Queries | `queries/` | TanStack Query hooks using Server Actions as `queryFn` | Direct repository/service calls from client |
-    | Mutations | `mutations/` | `useMutation` with cache invalidation | Direct repository/service calls from client |
-    | Hooks | `hooks/` | Composed hooks combining queries + mutations | Business logic |
-    | Components | `src/components/`, `src/features/*/` | Import from `hooks/` layer only | Import directly from `queries/` or `mutations/` |
-  </Layer_Architecture_Rules>
 
   <Review_Checklist>
     ### Layer Boundary Violations (HIGH)


### PR DESCRIPTION
## 완료 조건 체크리스트

- [x] `.claude/agents/domain-reviewer.md` 파일이 존재한다
- [x] Role이 명확히 정의되어 있다 (assassin 레이어 경계, RLS, zod 스키마 기준 리뷰)
- [x] 사용할 스킬 목록이 명시되어 있다 (assassin-feature, assassin-migration, vercel-react-best-practices)
- [x] OMC code-reviewer와 중복되지 않는 체크 항목만 포함한다

## 변경 내용

`.claude/agents/domain-reviewer.md` 신규 추가

OMC 기본 `code-reviewer`는 assassin 앱의 프로젝트 고유 패턴을 모름.
이 에이전트는 그 격차만 채움:

- 레이어 경계 위반 (components → queries 직접 import 등)
- Server Actions 인증 컨벤션 (`getCurrentUser()`, `userId` 클라이언트 수신 금지)
- RLS 누락 (userId 컬럼이 있는 신규 테이블)
- Zod/Prisma 패턴 (`z.infer`, `safeParse`, default export 등)

## 참고

빌드 실패(`generated/prisma/client` 미존재)는 dev 브랜치에서도 동일하게 발생하는 기존 환경 문제로 이번 PR과 무관합니다.

closes #125