### PR TITLE
[#134] 곡 세부 페이지 연주자 목록 악기 순 정렬

### DIFF
--- a/apps/assassin/src/features/player/hooks/usePlayerLogic.ts
+++ b/apps/assassin/src/features/player/hooks/usePlayerLogic.ts
@@ -1,19 +1,9 @@
-import { useCallback, useMemo } from "react";
+import { useCallback } from "react";
 import { usePlayersBySong } from "../queries/usePlayersBySong";
 import type { Player } from "../schema";
 
-const INSTRUMENT_ORDER = ["DRUM", "GUITAR", "BASS", "KEYBOARD", "VOCAL"] as const;
-
 export const usePlayerLogic = (songId: string) => {
-  const { data: rawPlayers = [] } = usePlayersBySong(songId);
-
-  const players = useMemo(
-    () =>
-      [...rawPlayers].sort(
-        (a, b) => INSTRUMENT_ORDER.indexOf(a.instrument) - INSTRUMENT_ORDER.indexOf(b.instrument),
-      ),
-    [rawPlayers],
-  );
+  const { data: players = [] } = usePlayersBySong(songId);
 
   const playersByInstrument = useCallback((): Record<string, Player[]> => {
     return players.reduce(

--- a/apps/assassin/src/features/player/queries/usePlayersBySong.ts
+++ b/apps/assassin/src/features/player/queries/usePlayersBySong.ts
@@ -2,9 +2,15 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { getPlayersBySongAction } from "../actions";
 import { playerKeys } from "./keys";
 
+const INSTRUMENT_ORDER = ["DRUM", "GUITAR", "BASS", "KEYBOARD", "VOCAL"] as const;
+
 export const usePlayersBySong = (songId: string) => {
   return useSuspenseQuery({
     queryKey: playerKeys.bySong(songId),
     queryFn: () => getPlayersBySongAction(songId),
+    select: (data) =>
+      [...data].sort(
+        (a, b) => INSTRUMENT_ORDER.indexOf(a.instrument) - INSTRUMENT_ORDER.indexOf(b.instrument),
+      ),
   });
 };


### PR DESCRIPTION
## Summary
- 연주자 목록이 추가 순서가 아닌 악기 순서로 항상 정렬되도록 수정

## 변경 사항
- `usePlayerLogic.ts`: `rawPlayers`를 `INSTRUMENT_ORDER` 기준으로 정렬 후 반환
- 정렬 순서: 드럼 → 기타 → 베이스 → 키보드 → 보컬

## 완료 조건 체크리스트
- [x] 연주자 목록이 드럼 → 기타 → 베이스 → 키보드 → 보컬 순서로 항상 정렬됨
- [x] 같은 악기 내에서는 기존 순서(추가 순) 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)