### PR TITLE
fix(assassin): reset local Supabase DB by default and silence demo user errors

### DIFF
--- a/apps/assassin/supabase/setup-local-supabase.sh
+++ b/apps/assassin/supabase/setup-local-supabase.sh
@@ -31,6 +31,14 @@ else
   supabase start
 fi
 
+# Local setup script should be deterministic. Reset DB by default to avoid
+# schema drift between older snake_case columns and newer camelCase schema.
+# Set SUPABASE_RESET_DB=0 to skip reset.
+if [[ "${SUPABASE_RESET_DB:-1}" == "1" ]]; then
+  echo "Resetting local Supabase DB (SUPABASE_RESET_DB=1)"
+  supabase db reset --local --no-seed
+fi
+
 status_json=$(supabase status --output json)
 
 # Derive local DB URL and container name from supabase status
@@ -85,7 +93,7 @@ for email, name in demo_users:
         "email_confirm": True,
         "user_metadata": {"name": name},
     })
-    subprocess.run(
+    result = subprocess.run(
         [
             "curl", "-s", "-X", "POST",
             f"{api_url}/auth/v1/admin/users",
@@ -95,7 +103,13 @@ for email, name in demo_users:
             "-d", payload,
         ],
         check=False,
+        capture_output=True,
+        text=True,
     )
+    # idempotent: ignore existing user errors and keep output readable
+    body = (result.stdout or "").strip()
+    if body and '"email_exists"' not in body:
+        print(body)
 PY
 
 # Drop cross-schema FK before Prisma introspects (Prisma cannot manage auth schema)


### PR DESCRIPTION
### Motivation
- Repeated local runs produced schema drift (snake_case vs camelCase) which caused migration noise and `prisma db push` failures due to conflicting constraints and indexes. 
- The local setup should be deterministic and idempotent so developers can re-run it without manual DB cleanup or noisy logs.

### Description
- Adds a default DB reset step to `apps/assassin/supabase/setup-local-supabase.sh` that runs `supabase db reset --local --no-seed` unless `SUPABASE_RESET_DB=0` is set. 
- Makes demo auth-user creation idempotent and quieter by capturing `curl` output in the embedded Python and ignoring expected `"email_exists"` responses. 
- Changes are limited to `apps/assassin/supabase/setup-local-supabase.sh` and preserve an opt-out for developers who want to keep their local DB state.

### Testing
- Ran `bash -n apps/assassin/supabase/setup-local-supabase.sh` to verify shell syntax, which succeeded. 
- Created the change and committed it with `git commit`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb86957d4c83308959e9b9200df01a)