### PR TITLE
Namespace season/calendar query keys by orgId and add OrgProvider safety

### DIFF
--- a/apps/assassin/src/app/org/[orgSlug]/calendar/page.tsx
+++ b/apps/assassin/src/app/org/[orgSlug]/calendar/page.tsx
@@ -46,12 +46,12 @@ async function CalendarDataFetch({ params, searchParams }: CalendarPageProps) {
 
   const queryClient = getQueryClient();
   await queryClient.prefetchQuery({
-    queryKey: calendarEventKeys.lists(year, month),
+    queryKey: calendarEventKeys.lists(org.id, year, month),
     queryFn: () => getCachedCalendarEvents(year, month, org.id),
   });
 
   const events =
-    queryClient.getQueryData<CalendarEvent[]>(calendarEventKeys.lists(year, month)) ?? [];
+    queryClient.getQueryData<CalendarEvent[]>(calendarEventKeys.lists(org.id, year, month)) ?? [];
   await Promise.all(
     events.flatMap((event) => [
       queryClient.prefetchQuery({

--- a/apps/assassin/src/app/org/[orgSlug]/season/page.tsx
+++ b/apps/assassin/src/app/org/[orgSlug]/season/page.tsx
@@ -38,7 +38,7 @@ async function OrgSeasonPageData({ orgId }: { orgId: string }) {
 
   const queryClient = getQueryClient();
   const seasons = await queryClient.fetchQuery({
-    queryKey: seasonKeys.lists(),
+    queryKey: seasonKeys.lists(orgId),
     queryFn: () => getSeasonsAction(orgId),
   });
 

--- a/apps/assassin/src/app/org/[orgSlug]/song/[songId]/page.tsx
+++ b/apps/assassin/src/app/org/[orgSlug]/song/[songId]/page.tsx
@@ -52,7 +52,7 @@ async function OrgSongPageContent({ songId, orgId }: { songId: string; orgId: st
   }
 
   const seasons = await queryClient.fetchQuery({
-    queryKey: seasonKeys.lists(),
+    queryKey: seasonKeys.lists(orgId),
     queryFn: () => getSeasonsAction(orgId),
   });
 

--- a/apps/assassin/src/components/calendar/EventSongAddForm.tsx
+++ b/apps/assassin/src/components/calendar/EventSongAddForm.tsx
@@ -23,7 +23,7 @@ export function EventSongAddForm({ eventId }: { eventId: string }) {
 
   const orgId = useOrgId();
   const { data: seasons = [] } = useQuery({
-    queryKey: seasonKeys.lists(),
+    queryKey: seasonKeys.lists(orgId),
     queryFn: () => getSeasonsAction(orgId),
     staleTime: 1000 * 60,
   });

--- a/apps/assassin/src/features/calendar/queries/keys.ts
+++ b/apps/assassin/src/features/calendar/queries/keys.ts
@@ -1,4 +1,5 @@
 export const calendarEventKeys = {
   all: ["calendarEvents"] as const,
-  lists: (year?: number, month?: number) => [...calendarEventKeys.all, "list", { year, month }] as const,
+  lists: (orgId: string, year?: number, month?: number) =>
+    [...calendarEventKeys.all, "list", { orgId, year, month }] as const,
 };

--- a/apps/assassin/src/features/calendar/queries/useCalendarEvents.ts
+++ b/apps/assassin/src/features/calendar/queries/useCalendarEvents.ts
@@ -7,7 +7,7 @@ import { useOrgId } from "@libs/org/OrgProvider";
 export const useCalendarEvents = (year: number, month: number) => {
   const orgId = useOrgId();
   return useSuspenseQuery({
-    queryKey: calendarEventKeys.lists(year, month),
+    queryKey: calendarEventKeys.lists(orgId, year, month),
     queryFn: () => getCalendarEventsByMonthAction(year, month, orgId),
     select: (data: CalendarEvent[]) =>
       [...data].sort((a, b) => {

--- a/apps/assassin/src/features/season/hooks/useRealtimeSeasonSync.ts
+++ b/apps/assassin/src/features/season/hooks/useRealtimeSeasonSync.ts
@@ -3,9 +3,11 @@ import { useQueryClient } from "@tanstack/react-query";
 import type { Season } from "@features/season/schema";
 import { seasonKeys } from "@features/season/queries/keys";
 import { createBrowserSupabaseClient } from "@/libs/supabase/client";
+import { useOrgId } from "@libs/org/OrgProvider";
 
 export const useRealtimeSeasonSync = () => {
   const queryClient = useQueryClient();
+  const orgId = useOrgId();
 
   const supabase = useMemo(() => createBrowserSupabaseClient(), []);
 
@@ -18,7 +20,7 @@ export const useRealtimeSeasonSync = () => {
         if (eventType === "DELETE") {
           const deletedId = (payload.old as Season | undefined)?.id;
           if (!deletedId) return;
-          queryClient.setQueryData(seasonKeys.lists(), (prev: Season[] | undefined) =>
+          queryClient.setQueryData(seasonKeys.lists(orgId), (prev: Season[] | undefined) =>
             prev ? prev.filter((season) => season.id !== deletedId) : prev,
           );
           queryClient.removeQueries({ queryKey: seasonKeys.detail(deletedId) });
@@ -29,7 +31,7 @@ export const useRealtimeSeasonSync = () => {
         if (!nextSeason) return;
 
         if (eventType === "INSERT") {
-          queryClient.setQueryData(seasonKeys.lists(), (prev: Season[] | undefined) =>
+          queryClient.setQueryData(seasonKeys.lists(orgId), (prev: Season[] | undefined) =>
             prev ? [...prev, nextSeason] : [nextSeason],
           );
           queryClient.setQueryData(seasonKeys.detail(nextSeason.id), nextSeason);
@@ -37,7 +39,7 @@ export const useRealtimeSeasonSync = () => {
         }
 
         // UPDATE
-        queryClient.setQueryData(seasonKeys.lists(), (prev: Season[] | undefined) => {
+        queryClient.setQueryData(seasonKeys.lists(orgId), (prev: Season[] | undefined) => {
           if (!prev) return prev;
           return prev.map((season) =>
             season.id === nextSeason.id ? { ...season, ...nextSeason } : season,
@@ -50,5 +52,5 @@ export const useRealtimeSeasonSync = () => {
     return () => {
       supabase.removeChannel(seasonsChannel);
     };
-  }, [queryClient, supabase]);
+  }, [orgId, queryClient, supabase]);
 };

--- a/apps/assassin/src/features/season/mutations/useCreateSeason.ts
+++ b/apps/assassin/src/features/season/mutations/useCreateSeason.ts
@@ -2,9 +2,11 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { createSeasonAction } from "../actions";
 import { seasonKeys } from "../queries/keys";
 import type { Season, SeasonPayload } from "../schema";
+import { useOrgId } from "@libs/org/OrgProvider";
 
 export const useCreateSeason = () => {
   const queryClient = useQueryClient();
+  const orgId = useOrgId();
 
   return useMutation({
     mutationFn: (data: SeasonPayload) => createSeasonAction(data),
@@ -13,7 +15,7 @@ export const useCreateSeason = () => {
 
       queryClient.setQueryData(seasonKeys.detail(createdSeason.id), createdSeason);
 
-      queryClient.setQueryData(seasonKeys.lists(), (prev: Season[] | undefined) => {
+      queryClient.setQueryData(seasonKeys.lists(orgId), (prev: Season[] | undefined) => {
         if (!prev) return [createdSeason];
         return [...prev, createdSeason];
       });

--- a/apps/assassin/src/features/season/mutations/useUpdateSeason.ts
+++ b/apps/assassin/src/features/season/mutations/useUpdateSeason.ts
@@ -2,9 +2,11 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { updateSeasonAction } from "../actions";
 import { seasonKeys } from "../queries/keys";
 import type { Season, SeasonUpdatePayload } from "../schema";
+import { useOrgId } from "@libs/org/OrgProvider";
 
 export const useUpdateSeason = () => {
   const queryClient = useQueryClient();
+  const orgId = useOrgId();
 
   return useMutation({
     mutationFn: ({ id, data }: { id: string; data: SeasonUpdatePayload }) =>
@@ -14,7 +16,7 @@ export const useUpdateSeason = () => {
 
       queryClient.setQueryData(seasonKeys.detail(updatedSeason.id), updatedSeason);
 
-      queryClient.setQueryData(seasonKeys.lists(), (prev: Season[] | undefined) => {
+      queryClient.setQueryData(seasonKeys.lists(orgId), (prev: Season[] | undefined) => {
         if (!prev) return [updatedSeason];
         const exists = prev.some((season) => season.id === updatedSeason.id);
         if (!exists) return [...prev, updatedSeason];

--- a/apps/assassin/src/features/season/queries/keys.ts
+++ b/apps/assassin/src/features/season/queries/keys.ts
@@ -1,5 +1,5 @@
 export const seasonKeys = {
   all: ["seasons"] as const,
-  lists: () => [...seasonKeys.all, "list"] as const,
+  lists: (orgId: string) => [...seasonKeys.all, "list", { orgId }] as const,
   detail: (id: string) => [...seasonKeys.all, "detail", id] as const,
 };

--- a/apps/assassin/src/features/season/queries/useSeasons.ts
+++ b/apps/assassin/src/features/season/queries/useSeasons.ts
@@ -6,7 +6,7 @@ import { useOrgId } from "@libs/org/OrgProvider";
 export const useSeasons = () => {
   const orgId = useOrgId();
   return useSuspenseQuery({
-    queryKey: seasonKeys.lists(),
+    queryKey: seasonKeys.lists(orgId),
     queryFn: () => getSeasonsAction(orgId),
   });
 };

--- a/apps/assassin/src/libs/org/OrgProvider.tsx
+++ b/apps/assassin/src/libs/org/OrgProvider.tsx
@@ -2,12 +2,18 @@
 
 import { createContext, useContext } from "react";
 
-const OrgContext = createContext<{ orgId: string }>({ orgId: "" });
+const OrgContext = createContext<{ orgId: string } | null>(null);
 
 export function OrgProvider({ orgId, children }: { orgId: string; children: React.ReactNode }) {
   return <OrgContext.Provider value={{ orgId }}>{children}</OrgContext.Provider>;
 }
 
 export function useOrgId(): string {
-  return useContext(OrgContext).orgId;
+  const context = useContext(OrgContext);
+
+  if (!context) {
+    throw new Error("useOrgId must be used within OrgProvider");
+  }
+
+  return context.orgId;
 }


### PR DESCRIPTION
### Motivation

- Scope React Query keys and cache to the current organization to prevent cross-org data leakage and ensure correct cache invalidation.
- Thread `orgId` through season/calendar queries, prefetches, and mutations so data is fetched and updated per-org.
- Make `useOrgId` robust by validating that it is used inside an `OrgProvider`.

### Description

- Changed `seasonKeys.lists` and `calendarEventKeys.lists` to accept `orgId` and updated all call sites to pass the current `orgId` (pages, hooks, components, and mutation callbacks). 
- Updated server/client page prefetches and query usages in `calendar/page.tsx`, `season/page.tsx`, `song/[songId]/page.tsx`, and `EventSongAddForm.tsx` to include `orgId` in query keys and fetch functions.
- Updated season-related hooks and mutations (`useSeasons`, `useRealtimeSeasonSync`, `useCreateSeason`, `useUpdateSeason`) to use `orgId` for list keys and added `orgId` to the effect dependency array in realtime sync.
- Made `OrgProvider` context nullable and added a guard in `useOrgId` that throws an error when used outside of the provider.

### Testing

- Ran TypeScript typecheck with `yarn tsc` and resolved type errors introduced by the signature changes (success).
- Ran the test suite with `yarn test` and existing unit tests covering query key behavior and hooks passed (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce5ecab4008330a39a9f2aa7da3f57)