### PR TITLE
Scope queries/mutations by orgId and make OrgProvider required

### DIFF
--- a/apps/assassin/src/app/org/[orgSlug]/calendar/page.tsx
+++ b/apps/assassin/src/app/org/[orgSlug]/calendar/page.tsx
@@ -46,12 +46,12 @@ async function CalendarDataFetch({ params, searchParams }: CalendarPageProps) {
 
   const queryClient = getQueryClient();
   await queryClient.prefetchQuery({
-    queryKey: calendarEventKeys.lists(year, month),
+    queryKey: calendarEventKeys.lists(org.id, year, month),
     queryFn: () => getCachedCalendarEvents(year, month, org.id),
   });
 
   const events =
-    queryClient.getQueryData<CalendarEvent[]>(calendarEventKeys.lists(year, month)) ?? [];
+    queryClient.getQueryData<CalendarEvent[]>(calendarEventKeys.lists(org.id, year, month)) ?? [];
   await Promise.all(
     events.flatMap((event) => [
       queryClient.prefetchQuery({

--- a/apps/assassin/src/app/org/[orgSlug]/season/page.tsx
+++ b/apps/assassin/src/app/org/[orgSlug]/season/page.tsx
@@ -38,7 +38,7 @@ async function OrgSeasonPageData({ orgId }: { orgId: string }) {
 
   const queryClient = getQueryClient();
   const seasons = await queryClient.fetchQuery({
-    queryKey: seasonKeys.lists(),
+    queryKey: seasonKeys.lists(orgId),
     queryFn: () => getSeasonsAction(orgId),
   });
 

--- a/apps/assassin/src/app/org/[orgSlug]/song/[songId]/page.tsx
+++ b/apps/assassin/src/app/org/[orgSlug]/song/[songId]/page.tsx
@@ -52,7 +52,7 @@ async function OrgSongPageContent({ songId, orgId }: { songId: string; orgId: st
   }
 
   const seasons = await queryClient.fetchQuery({
-    queryKey: seasonKeys.lists(),
+    queryKey: seasonKeys.lists(orgId),
     queryFn: () => getSeasonsAction(orgId),
   });
 

--- a/apps/assassin/src/components/calendar/EventSongAddForm.tsx
+++ b/apps/assassin/src/components/calendar/EventSongAddForm.tsx
@@ -23,7 +23,7 @@ export function EventSongAddForm({ eventId }: { eventId: string }) {
 
   const orgId = useOrgId();
   const { data: seasons = [] } = useQuery({
-    queryKey: seasonKeys.lists(),
+    queryKey: seasonKeys.lists(orgId),
     queryFn: () => getSeasonsAction(orgId),
     staleTime: 1000 * 60,
   });

--- a/apps/assassin/src/features/calendar/queries/keys.ts
+++ b/apps/assassin/src/features/calendar/queries/keys.ts
@@ -1,4 +1,5 @@
 export const calendarEventKeys = {
   all: ["calendarEvents"] as const,
-  lists: (year?: number, month?: number) => [...calendarEventKeys.all, "list", { year, month }] as const,
+  lists: (orgId: string, year?: number, month?: number) =>
+    [...calendarEventKeys.all, "list", { orgId, year, month }] as const,
 };

--- a/apps/assassin/src/features/calendar/queries/useCalendarEvents.ts
+++ b/apps/assassin/src/features/calendar/queries/useCalendarEvents.ts
@@ -7,7 +7,7 @@ import { useOrgId } from "@libs/org/OrgProvider";
 export const useCalendarEvents = (year: number, month: number) => {
   const orgId = useOrgId();
   return useSuspenseQuery({
-    queryKey: calendarEventKeys.lists(year, month),
+    queryKey: calendarEventKeys.lists(orgId, year, month),
     queryFn: () => getCalendarEventsByMonthAction(year, month, orgId),
     select: (data: CalendarEvent[]) =>
       [...data].sort((a, b) => {

--- a/apps/assassin/src/features/season/hooks/useRealtimeSeasonSync.ts
+++ b/apps/assassin/src/features/season/hooks/useRealtimeSeasonSync.ts
@@ -3,9 +3,11 @@ import { useQueryClient } from "@tanstack/react-query";
 import type { Season } from "@features/season/schema";
 import { seasonKeys } from "@features/season/queries/keys";
 import { createBrowserSupabaseClient } from "@/libs/supabase/client";
+import { useOrgId } from "@libs/org/OrgProvider";
 
 export const useRealtimeSeasonSync = () => {
   const queryClient = useQueryClient();
+  const orgId = useOrgId();
 
   const supabase = useMemo(() => createBrowserSupabaseClient(), []);
 
@@ -18,7 +20,7 @@ export const useRealtimeSeasonSync = () => {
         if (eventType === "DELETE") {
           const deletedId = (payload.old as Season | undefined)?.id;
           if (!deletedId) return;
-          queryClient.setQueryData(seasonKeys.lists(), (prev: Season[] | undefined) =>
+          queryClient.setQueryData(seasonKeys.lists(orgId), (prev: Season[] | undefined) =>
             prev ? prev.filter((season) => season.id !== deletedId) : prev,
           );
           queryClient.removeQueries({ queryKey: seasonKeys.detail(deletedId) });
@@ -29,7 +31,7 @@ export const useRealtimeSeasonSync = () => {
         if (!nextSeason) return;
 
         if (eventType === "INSERT") {
-          queryClient.setQueryData(seasonKeys.lists(), (prev: Season[] | undefined) =>
+          queryClient.setQueryData(seasonKeys.lists(orgId), (prev: Season[] | undefined) =>
             prev ? [...prev, nextSeason] : [nextSeason],
           );
           queryClient.setQueryData(seasonKeys.detail(nextSeason.id), nextSeason);
@@ -37,7 +39,7 @@ export const useRealtimeSeasonSync = () => {
         }
 
         // UPDATE
-        queryClient.setQueryData(seasonKeys.lists(), (prev: Season[] | undefined) => {
+        queryClient.setQueryData(seasonKeys.lists(orgId), (prev: Season[] | undefined) => {
           if (!prev) return prev;
           return prev.map((season) =>
             season.id === nextSeason.id ? { ...season, ...nextSeason } : season,
@@ -50,5 +52,5 @@ export const useRealtimeSeasonSync = () => {
     return () => {
       supabase.removeChannel(seasonsChannel);
     };
-  }, [queryClient, supabase]);
+  }, [orgId, queryClient, supabase]);
 };

--- a/apps/assassin/src/features/season/mutations/useCreateSeason.ts
+++ b/apps/assassin/src/features/season/mutations/useCreateSeason.ts
@@ -2,18 +2,20 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { createSeasonAction } from "../actions";
 import { seasonKeys } from "../queries/keys";
 import type { Season, SeasonPayload } from "../schema";
+import { useOrgId } from "@libs/org/OrgProvider";
 
 export const useCreateSeason = () => {
   const queryClient = useQueryClient();
+  const orgId = useOrgId();
 
   return useMutation({
-    mutationFn: (data: SeasonPayload) => createSeasonAction(data),
+    mutationFn: (data: SeasonPayload) => createSeasonAction(data, orgId),
     onSuccess: (createdSeason) => {
       if (!createdSeason) return;
 
       queryClient.setQueryData(seasonKeys.detail(createdSeason.id), createdSeason);
 
-      queryClient.setQueryData(seasonKeys.lists(), (prev: Season[] | undefined) => {
+      queryClient.setQueryData(seasonKeys.lists(orgId), (prev: Season[] | undefined) => {
         if (!prev) return [createdSeason];
         return [...prev, createdSeason];
       });

--- a/apps/assassin/src/features/season/mutations/useUpdateSeason.ts
+++ b/apps/assassin/src/features/season/mutations/useUpdateSeason.ts
@@ -2,19 +2,21 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { updateSeasonAction } from "../actions";
 import { seasonKeys } from "../queries/keys";
 import type { Season, SeasonUpdatePayload } from "../schema";
+import { useOrgId } from "@libs/org/OrgProvider";
 
 export const useUpdateSeason = () => {
   const queryClient = useQueryClient();
+  const orgId = useOrgId();
 
   return useMutation({
     mutationFn: ({ id, data }: { id: string; data: SeasonUpdatePayload }) =>
-      updateSeasonAction(id, data),
+      updateSeasonAction(id, orgId, data),
     onSuccess: (updatedSeason) => {
       if (!updatedSeason) return;
 
       queryClient.setQueryData(seasonKeys.detail(updatedSeason.id), updatedSeason);
 
-      queryClient.setQueryData(seasonKeys.lists(), (prev: Season[] | undefined) => {
+      queryClient.setQueryData(seasonKeys.lists(orgId), (prev: Season[] | undefined) => {
         if (!prev) return [updatedSeason];
         const exists = prev.some((season) => season.id === updatedSeason.id);
         if (!exists) return [...prev, updatedSeason];

--- a/apps/assassin/src/features/season/queries/keys.ts
+++ b/apps/assassin/src/features/season/queries/keys.ts
@@ -1,5 +1,5 @@
 export const seasonKeys = {
   all: ["seasons"] as const,
-  lists: () => [...seasonKeys.all, "list"] as const,
+  lists: (orgId: string) => [...seasonKeys.all, "list", { orgId }] as const,
   detail: (id: string) => [...seasonKeys.all, "detail", id] as const,
 };

--- a/apps/assassin/src/features/season/queries/useSeasons.ts
+++ b/apps/assassin/src/features/season/queries/useSeasons.ts
@@ -6,7 +6,7 @@ import { useOrgId } from "@libs/org/OrgProvider";
 export const useSeasons = () => {
   const orgId = useOrgId();
   return useSuspenseQuery({
-    queryKey: seasonKeys.lists(),
+    queryKey: seasonKeys.lists(orgId),
     queryFn: () => getSeasonsAction(orgId),
   });
 };

--- a/apps/assassin/src/libs/org/OrgProvider.tsx
+++ b/apps/assassin/src/libs/org/OrgProvider.tsx
@@ -2,12 +2,18 @@
 
 import { createContext, useContext } from "react";
 
-const OrgContext = createContext<{ orgId: string }>({ orgId: "" });
+const OrgContext = createContext<{ orgId: string } | null>(null);
 
 export function OrgProvider({ orgId, children }: { orgId: string; children: React.ReactNode }) {
   return <OrgContext.Provider value={{ orgId }}>{children}</OrgContext.Provider>;
 }
 
 export function useOrgId(): string {
-  return useContext(OrgContext).orgId;
+  const context = useContext(OrgContext);
+
+  if (!context) {
+    throw new Error("useOrgId must be used within OrgProvider");
+  }
+
+  return context.orgId;
 }


### PR DESCRIPTION
### Motivation
- Ensure react-query cache keys and data fetching are scoped per organization so data doesn't leak across orgs.
- Pass `orgId` into server actions and mutation functions so backend requests operate in the correct org context.
- Make `useOrgId` safer by failing fast when used outside an `OrgProvider` to surface incorrect component usage.

### Description
- Updated calendar, season, and song pages to include `org.id` when prefetching and reading query cache keys and when calling actions like `getCalendarEventsByMonthAction` and `getSeasonsAction`.
- Changed query key factories to accept `orgId` (`calendarEventKeys.lists`, `seasonKeys.lists`) and updated hooks (`useCalendarEvents`, `useSeasons`) and components (`EventSongAddForm`) to use `useOrgId()` for keyed queries.
- Updated season realtime sync and season mutations (`useCreateSeason`, `useUpdateSeason`) to use `orgId` in query keys and to pass `orgId` into action functions; added `orgId` dependency to the realtime hook effect.
- Made `OrgProvider` context nullable and updated `useOrgId` to throw an error when called outside of `OrgProvider` to prevent silent failures.

### Testing
- Ran TypeScript typecheck and project build (`pnpm build`) to validate types and imports, which completed successfully.
- Executed the existing unit/integration test suite (`pnpm test`), and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce5ecab4008330a39a9f2aa7da3f57)