### PR TITLE
Scope queries and routes by organization; add OrgProvider guard

### DIFF
--- a/apps/assassin/src/app/org/[orgSlug]/calendar/page.tsx
+++ b/apps/assassin/src/app/org/[orgSlug]/calendar/page.tsx
@@ -46,12 +46,12 @@ async function CalendarDataFetch({ params, searchParams }: CalendarPageProps) {
 
   const queryClient = getQueryClient();
   await queryClient.prefetchQuery({
-    queryKey: calendarEventKeys.lists(year, month),
+    queryKey: calendarEventKeys.lists(org.id, year, month),
     queryFn: () => getCachedCalendarEvents(year, month, org.id),
   });
 
   const events =
-    queryClient.getQueryData<CalendarEvent[]>(calendarEventKeys.lists(year, month)) ?? [];
+    queryClient.getQueryData<CalendarEvent[]>(calendarEventKeys.lists(org.id, year, month)) ?? [];
   await Promise.all(
     events.flatMap((event) => [
       queryClient.prefetchQuery({

--- a/apps/assassin/src/app/org/[orgSlug]/season/page.tsx
+++ b/apps/assassin/src/app/org/[orgSlug]/season/page.tsx
@@ -38,7 +38,7 @@ async function OrgSeasonPageData({ orgId }: { orgId: string }) {
 
   const queryClient = getQueryClient();
   const seasons = await queryClient.fetchQuery({
-    queryKey: seasonKeys.lists(),
+    queryKey: seasonKeys.lists(orgId),
     queryFn: () => getSeasonsAction(orgId),
   });
 

--- a/apps/assassin/src/app/org/[orgSlug]/song/[songId]/page.tsx
+++ b/apps/assassin/src/app/org/[orgSlug]/song/[songId]/page.tsx
@@ -52,7 +52,7 @@ async function OrgSongPageContent({ songId, orgId }: { songId: string; orgId: st
   }
 
   const seasons = await queryClient.fetchQuery({
-    queryKey: seasonKeys.lists(),
+    queryKey: seasonKeys.lists(orgId),
     queryFn: () => getSeasonsAction(orgId),
   });
 

--- a/apps/assassin/src/components/calendar/EventSongAddForm.tsx
+++ b/apps/assassin/src/components/calendar/EventSongAddForm.tsx
@@ -23,7 +23,7 @@ export function EventSongAddForm({ eventId }: { eventId: string }) {
 
   const orgId = useOrgId();
   const { data: seasons = [] } = useQuery({
-    queryKey: seasonKeys.lists(),
+    queryKey: seasonKeys.lists(orgId),
     queryFn: () => getSeasonsAction(orgId),
     staleTime: 1000 * 60,
   });

--- a/apps/assassin/src/components/season/SeasonColumn.tsx
+++ b/apps/assassin/src/components/season/SeasonColumn.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { Season } from "@features/season/schema";
 import type { Song } from "@features/song/schema";
 import { useUpdateSeason } from "@features/season/mutations/useUpdateSeason";
@@ -256,6 +256,7 @@ function SeasonSongListDrag({ seasonId, songs, songCount, onAdd }: SeasonSongLis
 
 function SeasonSongListStatic({ songs, songCount, onAdd }: SeasonSongListProps) {
   const router = useRouter();
+  const params = useParams<{ orgSlug?: string }>();
 
   return (
     <div className="flex-1 min-h-0 overflow-y-auto scrollbar-hidden rounded-md bg-slate-50 dark:bg-slate-900 p-3 sm:p-4">
@@ -264,7 +265,15 @@ function SeasonSongListStatic({ songs, songCount, onAdd }: SeasonSongListProps) 
       ) : (
         <div className="space-y-2">
           {songs.map((song) => (
-            <SongItem key={song.id} song={song} onClick={() => router.push(`/song/${song.id}`)} />
+            <SongItem
+              key={song.id}
+              song={song}
+              onClick={() =>
+                router.push(
+                  params.orgSlug ? `/org/${params.orgSlug}/song/${song.id}` : `/song/${song.id}`,
+                )
+              }
+            />
           ))}
         </div>
       )}

--- a/apps/assassin/src/components/song/SongDetailModal.tsx
+++ b/apps/assassin/src/components/song/SongDetailModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Suspense } from "react";
-import { usePathname } from "next/navigation";
+import { useParams, usePathname } from "next/navigation";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Separator } from "@/components/ui/separator";
 import { Music } from "lucide-react";
@@ -20,6 +20,7 @@ interface SongDetailModalProps {
 
 export function SongDetailModal({ songId, open, onOpenChange }: SongDetailModalProps) {
   const pathname = usePathname();
+  const params = useParams<{ orgSlug?: string }>();
 
   const song = useSong(songId).data;
 
@@ -28,7 +29,8 @@ export function SongDetailModal({ songId, open, onOpenChange }: SongDetailModalP
   }
 
   const youtubeId = extractYoutubeId(song.youtubeUrl);
-  const isActiveRoute = pathname === `/song/${song.id}`;
+  const songRoute = params.orgSlug ? `/org/${params.orgSlug}/song/${song.id}` : `/song/${song.id}`;
+  const isActiveRoute = pathname === songRoute;
   const shouldRenderIframe = Boolean(youtubeId && isActiveRoute);
 
   return (

--- a/apps/assassin/src/components/song/SongDetailPage.tsx
+++ b/apps/assassin/src/components/song/SongDetailPage.tsx
@@ -1,17 +1,20 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { SongDetailModal } from "./SongDetailModal";
 
 export function SongDetailPage({ songId }: { songId: string }) {
   const router = useRouter();
+  const params = useParams<{ orgSlug?: string }>();
 
   return (
     <SongDetailModal
       songId={songId}
       open={true}
       onOpenChange={(isOpen) => {
-        if (!isOpen) router.push("/");
+        if (!isOpen) {
+          router.push(params.orgSlug ? `/org/${params.orgSlug}/season` : "/");
+        }
       }}
     />
   );

--- a/apps/assassin/src/components/song/SortableSongItem.tsx
+++ b/apps/assassin/src/components/song/SortableSongItem.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useSyncExternalStore } from "react";
 import type { CSSProperties } from "react";
-import { useRouter } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import type { Song } from "@features/song/schema";
@@ -20,6 +20,7 @@ export function SortableSongItem({ song }: SortableSongItemProps) {
     () => false,
   );
   const router = useRouter();
+  const params = useParams<{ orgSlug?: string }>();
   const sortable = useSortable({
     id: song.id,
     disabled: !isMounted,
@@ -36,8 +37,9 @@ export function SortableSongItem({ song }: SortableSongItemProps) {
 
   const handleClick = useCallback(() => {
     if (isDragging) return;
-    router.push(`/song/${song.id}`);
-  }, [isDragging, router, song.id]);
+    const songPath = params.orgSlug ? `/org/${params.orgSlug}/song/${song.id}` : `/song/${song.id}`;
+    router.push(songPath);
+  }, [isDragging, params.orgSlug, router, song.id]);
 
   if (!isMounted) {
     return <SongItem song={song} onClick={handleClick} className="cursor-grab" />;

--- a/apps/assassin/src/features/calendar/queries/keys.ts
+++ b/apps/assassin/src/features/calendar/queries/keys.ts
@@ -1,4 +1,5 @@
 export const calendarEventKeys = {
   all: ["calendarEvents"] as const,
-  lists: (year?: number, month?: number) => [...calendarEventKeys.all, "list", { year, month }] as const,
+  lists: (orgId: string, year?: number, month?: number) =>
+    [...calendarEventKeys.all, "list", { orgId, year, month }] as const,
 };

--- a/apps/assassin/src/features/calendar/queries/useCalendarEvents.ts
+++ b/apps/assassin/src/features/calendar/queries/useCalendarEvents.ts
@@ -7,7 +7,7 @@ import { useOrgId } from "@libs/org/OrgProvider";
 export const useCalendarEvents = (year: number, month: number) => {
   const orgId = useOrgId();
   return useSuspenseQuery({
-    queryKey: calendarEventKeys.lists(year, month),
+    queryKey: calendarEventKeys.lists(orgId, year, month),
     queryFn: () => getCalendarEventsByMonthAction(year, month, orgId),
     select: (data: CalendarEvent[]) =>
       [...data].sort((a, b) => {

--- a/apps/assassin/src/features/season/hooks/useRealtimeSeasonSync.ts
+++ b/apps/assassin/src/features/season/hooks/useRealtimeSeasonSync.ts
@@ -3,9 +3,11 @@ import { useQueryClient } from "@tanstack/react-query";
 import type { Season } from "@features/season/schema";
 import { seasonKeys } from "@features/season/queries/keys";
 import { createBrowserSupabaseClient } from "@/libs/supabase/client";
+import { useOrgId } from "@libs/org/OrgProvider";
 
 export const useRealtimeSeasonSync = () => {
   const queryClient = useQueryClient();
+  const orgId = useOrgId();
 
   const supabase = useMemo(() => createBrowserSupabaseClient(), []);
 
@@ -18,7 +20,7 @@ export const useRealtimeSeasonSync = () => {
         if (eventType === "DELETE") {
           const deletedId = (payload.old as Season | undefined)?.id;
           if (!deletedId) return;
-          queryClient.setQueryData(seasonKeys.lists(), (prev: Season[] | undefined) =>
+          queryClient.setQueryData(seasonKeys.lists(orgId), (prev: Season[] | undefined) =>
             prev ? prev.filter((season) => season.id !== deletedId) : prev,
           );
           queryClient.removeQueries({ queryKey: seasonKeys.detail(deletedId) });
@@ -29,7 +31,7 @@ export const useRealtimeSeasonSync = () => {
         if (!nextSeason) return;
 
         if (eventType === "INSERT") {
-          queryClient.setQueryData(seasonKeys.lists(), (prev: Season[] | undefined) =>
+          queryClient.setQueryData(seasonKeys.lists(orgId), (prev: Season[] | undefined) =>
             prev ? [...prev, nextSeason] : [nextSeason],
           );
           queryClient.setQueryData(seasonKeys.detail(nextSeason.id), nextSeason);
@@ -37,7 +39,7 @@ export const useRealtimeSeasonSync = () => {
         }
 
         // UPDATE
-        queryClient.setQueryData(seasonKeys.lists(), (prev: Season[] | undefined) => {
+        queryClient.setQueryData(seasonKeys.lists(orgId), (prev: Season[] | undefined) => {
           if (!prev) return prev;
           return prev.map((season) =>
             season.id === nextSeason.id ? { ...season, ...nextSeason } : season,
@@ -50,5 +52,5 @@ export const useRealtimeSeasonSync = () => {
     return () => {
       supabase.removeChannel(seasonsChannel);
     };
-  }, [queryClient, supabase]);
+  }, [orgId, queryClient, supabase]);
 };

--- a/apps/assassin/src/features/season/mutations/useCreateSeason.ts
+++ b/apps/assassin/src/features/season/mutations/useCreateSeason.ts
@@ -2,18 +2,20 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { createSeasonAction } from "../actions";
 import { seasonKeys } from "../queries/keys";
 import type { Season, SeasonPayload } from "../schema";
+import { useOrgId } from "@libs/org/OrgProvider";
 
 export const useCreateSeason = () => {
   const queryClient = useQueryClient();
+  const orgId = useOrgId();
 
   return useMutation({
-    mutationFn: (data: SeasonPayload) => createSeasonAction(data),
+    mutationFn: (data: SeasonPayload) => createSeasonAction(data, orgId),
     onSuccess: (createdSeason) => {
       if (!createdSeason) return;
 
       queryClient.setQueryData(seasonKeys.detail(createdSeason.id), createdSeason);
 
-      queryClient.setQueryData(seasonKeys.lists(), (prev: Season[] | undefined) => {
+      queryClient.setQueryData(seasonKeys.lists(orgId), (prev: Season[] | undefined) => {
         if (!prev) return [createdSeason];
         return [...prev, createdSeason];
       });

--- a/apps/assassin/src/features/season/mutations/useUpdateSeason.ts
+++ b/apps/assassin/src/features/season/mutations/useUpdateSeason.ts
@@ -2,19 +2,21 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { updateSeasonAction } from "../actions";
 import { seasonKeys } from "../queries/keys";
 import type { Season, SeasonUpdatePayload } from "../schema";
+import { useOrgId } from "@libs/org/OrgProvider";
 
 export const useUpdateSeason = () => {
   const queryClient = useQueryClient();
+  const orgId = useOrgId();
 
   return useMutation({
     mutationFn: ({ id, data }: { id: string; data: SeasonUpdatePayload }) =>
-      updateSeasonAction(id, data),
+      updateSeasonAction(id, orgId, data),
     onSuccess: (updatedSeason) => {
       if (!updatedSeason) return;
 
       queryClient.setQueryData(seasonKeys.detail(updatedSeason.id), updatedSeason);
 
-      queryClient.setQueryData(seasonKeys.lists(), (prev: Season[] | undefined) => {
+      queryClient.setQueryData(seasonKeys.lists(orgId), (prev: Season[] | undefined) => {
         if (!prev) return [updatedSeason];
         const exists = prev.some((season) => season.id === updatedSeason.id);
         if (!exists) return [...prev, updatedSeason];

--- a/apps/assassin/src/features/season/queries/keys.ts
+++ b/apps/assassin/src/features/season/queries/keys.ts
@@ -1,5 +1,5 @@
 export const seasonKeys = {
   all: ["seasons"] as const,
-  lists: () => [...seasonKeys.all, "list"] as const,
+  lists: (orgId: string) => [...seasonKeys.all, "list", { orgId }] as const,
   detail: (id: string) => [...seasonKeys.all, "detail", id] as const,
 };

--- a/apps/assassin/src/features/season/queries/useSeasons.ts
+++ b/apps/assassin/src/features/season/queries/useSeasons.ts
@@ -6,7 +6,7 @@ import { useOrgId } from "@libs/org/OrgProvider";
 export const useSeasons = () => {
   const orgId = useOrgId();
   return useSuspenseQuery({
-    queryKey: seasonKeys.lists(),
+    queryKey: seasonKeys.lists(orgId),
     queryFn: () => getSeasonsAction(orgId),
   });
 };

--- a/apps/assassin/src/libs/org/OrgProvider.tsx
+++ b/apps/assassin/src/libs/org/OrgProvider.tsx
@@ -2,12 +2,18 @@
 
 import { createContext, useContext } from "react";
 
-const OrgContext = createContext<{ orgId: string }>({ orgId: "" });
+const OrgContext = createContext<{ orgId: string } | null>(null);
 
 export function OrgProvider({ orgId, children }: { orgId: string; children: React.ReactNode }) {
   return <OrgContext.Provider value={{ orgId }}>{children}</OrgContext.Provider>;
 }
 
 export function useOrgId(): string {
-  return useContext(OrgContext).orgId;
+  const context = useContext(OrgContext);
+
+  if (!context) {
+    throw new Error("useOrgId must be used within OrgProvider");
+  }
+
+  return context.orgId;
 }


### PR DESCRIPTION
### Motivation
- Ensure query cache keys and data fetching are scoped to a specific organization (`orgId`) to avoid cross-org cache collisions.
- Make client-side routing for song/detail pages work when nested under an org path by reading `orgSlug` from route params.
- Improve safety of the org context by making `useOrgId` throw when used outside of `OrgProvider`.

### Description
- Updated query key factories to include `orgId` for calendar and season queries (e.g. `calendarEventKeys.lists`, `seasonKeys.lists`) and updated all call sites and prefetches to pass `orgId` where applicable.
- Changed hooks and mutations to use `useOrgId` and to pass `orgId` into actions (`useCreateSeason`, `useUpdateSeason`, `useCalendarEvents`, realtime season sync, etc.).
- Scoped realtime subscription updates to the org by adding `orgId` to query updates and effect dependencies in `useRealtimeSeasonSync`.
- Updated client components to honor `orgSlug` route parameter for navigation and active-route detection by using `useParams` (changes in `SeasonColumn`, `SortableSongItem`, `SongDetailModal`, `SongDetailPage`, `EventSongAddForm`, and related usage).
- Tightened `OrgProvider` context by allowing a nullable context and making `useOrgId` throw an error when called outside of `OrgProvider`.

### Testing
- Ran the project's automated test suite with `pnpm -w test` and the TypeScript type check (`pnpm -w build`), and both completed successfully.
- Ran linting with `pnpm -w lint` with no new lint errors reported.
- Verified dev server and client navigation locally to ensure route changes and query hydration behave as expected during manual smoke testing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce5ecab4008330a39a9f2aa7da3f57)