### PR TITLE
Propagate orgId to song/season APIs and use Suspense in RootLayout

### DIFF
--- a/apps/assassin/src/app/layout.tsx
+++ b/apps/assassin/src/app/layout.tsx
@@ -1,17 +1,7 @@
 import type { Metadata, Viewport } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Suspense } from "react";
 import "./globals.css";
 import Providers from "@libs/react-query/provider";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "합주",
@@ -45,10 +35,12 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko">
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+      <body className="antialiased">
         <Providers>
-          {children}
-          {modal}
+          <Suspense fallback={null}>
+            {children}
+            {modal}
+          </Suspense>
         </Providers>
       </body>
     </html>

--- a/apps/assassin/src/app/onboarding/page.tsx
+++ b/apps/assassin/src/app/onboarding/page.tsx
@@ -3,6 +3,12 @@ import Link from "next/link";
 import { createServerSupabaseClient } from "@libs/supabase/server";
 import { getUserOrgsAction } from "@features/org/actions";
 
+type OnboardingOrg = {
+  id: string;
+  slug: string;
+  name: string;
+};
+
 export default function OnboardingPage() {
   return (
     <Suspense>
@@ -17,7 +23,7 @@ async function OnboardingContent() {
     data: { user },
   } = await supabase.auth.getUser();
 
-  const orgs = user
+  const orgs: OnboardingOrg[] = user
     ? await getUserOrgsAction(user.id).catch((e) => {
         console.error("[Onboarding] getUserOrgsAction 실패:", e);
         return [];

--- a/apps/assassin/src/app/org/[orgSlug]/season/page.tsx
+++ b/apps/assassin/src/app/org/[orgSlug]/season/page.tsx
@@ -46,7 +46,7 @@ async function OrgSeasonPageData({ orgId }: { orgId: string }) {
     seasons.map((season) =>
       queryClient.prefetchQuery({
         queryKey: songKeys.bySeason(season.id),
-        queryFn: () => getSongsBySeasonAction(season.id),
+        queryFn: () => getSongsBySeasonAction(season.id, orgId),
       }),
     ),
   );

--- a/apps/assassin/src/app/org/[orgSlug]/song/[songId]/page.tsx
+++ b/apps/assassin/src/app/org/[orgSlug]/song/[songId]/page.tsx
@@ -60,7 +60,7 @@ async function OrgSongPageContent({ songId, orgId }: { songId: string; orgId: st
     seasons.map((season) =>
       queryClient.prefetchQuery({
         queryKey: songKeys.bySeason(season.id),
-        queryFn: () => getSongsBySeasonAction(season.id),
+        queryFn: () => getSongsBySeasonAction(season.id, orgId),
       }),
     ),
   );

--- a/apps/assassin/src/components/calendar/EventSongAddForm.tsx
+++ b/apps/assassin/src/components/calendar/EventSongAddForm.tsx
@@ -30,7 +30,7 @@ export function EventSongAddForm({ eventId }: { eventId: string }) {
 
   const { data: songs = [] } = useQuery({
     queryKey: songKeys.bySeason(selectedSeasonId),
-    queryFn: () => getSongsBySeasonAction(selectedSeasonId),
+    queryFn: () => getSongsBySeasonAction(selectedSeasonId, orgId),
     enabled: !!selectedSeasonId,
     staleTime: 1000 * 60,
   });

--- a/apps/assassin/src/features/season/queries/useSeason.ts
+++ b/apps/assassin/src/features/season/queries/useSeason.ts
@@ -1,10 +1,13 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { getSeasonAction } from "../actions";
 import { seasonKeys } from "./keys";
+import { useOrgId } from "@libs/org/OrgProvider";
 
 export const useSeason = (id: string) => {
+  const orgId = useOrgId();
+
   return useSuspenseQuery({
     queryKey: seasonKeys.detail(id),
-    queryFn: () => getSeasonAction(id),
+    queryFn: () => getSeasonAction(id, orgId),
   });
 };

--- a/apps/assassin/src/features/song/actions.ts
+++ b/apps/assassin/src/features/song/actions.ts
@@ -10,11 +10,11 @@ export const getSongAction = async (id: string) => {
   return await SongService.getSongById(id);
 };
 
-export const getSongsBySeasonAction = async (seasonId: string) => {
-  return await SongService.getSongsBySeasonId(seasonId);
+export const getSongsBySeasonAction = async (seasonId: string, orgId: string) => {
+  return await SongService.getSongsBySeasonId(seasonId, orgId);
 };
 
-export const createSongAction = async (data: {
+export const createSongAction = async (orgId: string, data: {
   seasonId: string;
   name: string;
   artist: string;
@@ -23,7 +23,7 @@ export const createSongAction = async (data: {
   sortOrder: number;
 }) => {
   const user = await getCurrentUser();
-  const result = await SongService.createSong({ ...data, userId: user.id });
+  const result = await SongService.createSong({ ...data, userId: user.id }, orgId);
   revalidateSeasonBoard();
   return result;
 };

--- a/apps/assassin/src/features/song/mutations/useCreateSong.ts
+++ b/apps/assassin/src/features/song/mutations/useCreateSong.ts
@@ -3,12 +3,14 @@ import { createSongAction } from "../actions";
 import { songKeys } from "../queries/keys";
 import type { SongFormData } from "../hooks/useSongForm";
 import type { Song } from "../schema";
+import { useOrgId } from "@libs/org/OrgProvider";
 
 export const useCreateSong = () => {
   const queryClient = useQueryClient();
+  const orgId = useOrgId();
 
   return useMutation({
-    mutationFn: (data: SongFormData) => createSongAction(data),
+    mutationFn: (data: SongFormData) => createSongAction(orgId, data),
     onSuccess: (createdSong) => {
       if (!createdSong) return;
       queryClient.setQueryData(songKeys.detail(createdSong.id), createdSong);

--- a/apps/assassin/src/features/song/queries/useSongsBySeason.ts
+++ b/apps/assassin/src/features/song/queries/useSongsBySeason.ts
@@ -1,10 +1,13 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { getSongsBySeasonAction } from "../actions";
 import { songKeys } from "./keys";
+import { useOrgId } from "@libs/org/OrgProvider";
 
 export const useSongsBySeason = (seasonId: string) => {
+  const orgId = useOrgId();
+
   return useSuspenseQuery({
     queryKey: songKeys.bySeason(seasonId),
-    queryFn: () => getSongsBySeasonAction(seasonId),
+    queryFn: () => getSongsBySeasonAction(seasonId, orgId),
   });
 };

--- a/apps/assassin/src/features/song/service.ts
+++ b/apps/assassin/src/features/song/service.ts
@@ -19,8 +19,8 @@ const assertSongExists = async (songId: string): Promise<void> => {
   }
 };
 
-const createSong = async (song: SongPayload) => {
-  await SeasonService.assertSeasonExists(song.seasonId);
+const createSong = async (song: SongPayload, orgId: string) => {
+  await SeasonService.assertSeasonExists(song.seasonId, orgId);
 
   let result;
   try {
@@ -70,8 +70,8 @@ const getSongById = async (id: string): Promise<Song | null> => {
   return parsed.data;
 };
 
-const getSongsBySeasonId = async (seasonId: string): Promise<Array<Song>> => {
-  await SeasonService.assertSeasonExists(seasonId);
+const getSongsBySeasonId = async (seasonId: string, orgId: string): Promise<Array<Song>> => {
+  await SeasonService.assertSeasonExists(seasonId, orgId);
 
   const songs = await SongRepository.getSongsBySeasonId(seasonId);
 


### PR DESCRIPTION
### Motivation
- Ensure song and season queries and mutations are scoped to the current organization so data returned/created belongs to the correct org.
- Fix prefetch and query calls that previously omitted `orgId`, which could cause incorrect or unauthorized data to be shown.
- Improve top-level rendering resilience by wrapping app children in `Suspense` and remove unused Google font variables to simplify layout.

### Description
- Added an `orgId` parameter to `getSongsBySeasonAction` and updated `SongService.getSongsBySeasonId` and `createSong` to accept `orgId` and assert season existence with org context.
- Updated action and mutation signatures: `createSongAction` now takes `orgId`, `useCreateSong` uses `useOrgId` and forwards `orgId`, and several query hooks (`useSongsBySeason`, `useSeason`) now call their actions with `orgId` obtained from `useOrgId`.
- Updated server and client pages and prefetches to pass `orgId` when fetching songs by season in `OrgSeasonPage`, `OrgSongPage`, and `EventSongAddForm`.
- Cleaned up root layout by removing `Geist` font imports and variables and wrapping `children`/`modal` in a `Suspense` boundary; added a small type (`OnboardingOrg`) used in onboarding page.

### Testing
- Ran TypeScript type check with `pnpm -w -s tsc` which completed successfully.
- Ran unit tests with `pnpm -w -s test` which passed.
- Built the app with `pnpm -w -s build` to ensure server/client bundles compile, and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce68d31cd8833098f72ec8a40295a1)