### PR TITLE
org 컨텍스트 기반으로 쿼리·라우팅·뮤테이션 범위 통일

### DIFF
--- a/apps/assassin/src/app/layout.tsx
+++ b/apps/assassin/src/app/layout.tsx
@@ -1,17 +1,7 @@
 import type { Metadata, Viewport } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Suspense } from "react";
 import "./globals.css";
 import Providers from "@libs/react-query/provider";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "합주",
@@ -45,10 +35,12 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko">
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+      <body className="antialiased">
         <Providers>
-          {children}
-          {modal}
+          <Suspense fallback={null}>
+            {children}
+            {modal}
+          </Suspense>
         </Providers>
       </body>
     </html>

--- a/apps/assassin/src/app/onboarding/page.tsx
+++ b/apps/assassin/src/app/onboarding/page.tsx
@@ -3,6 +3,12 @@ import Link from "next/link";
 import { createServerSupabaseClient } from "@libs/supabase/server";
 import { getUserOrgsAction } from "@features/org/actions";
 
+type OnboardingOrg = {
+  id: string;
+  slug: string;
+  name: string;
+};
+
 export default function OnboardingPage() {
   return (
     <Suspense>
@@ -17,7 +23,7 @@ async function OnboardingContent() {
     data: { user },
   } = await supabase.auth.getUser();
 
-  const orgs = user
+  const orgs: OnboardingOrg[] = user
     ? await getUserOrgsAction(user.id).catch((e) => {
         console.error("[Onboarding] getUserOrgsAction 실패:", e);
         return [];

--- a/apps/assassin/src/app/org/[orgSlug]/calendar/page.tsx
+++ b/apps/assassin/src/app/org/[orgSlug]/calendar/page.tsx
@@ -46,12 +46,12 @@ async function CalendarDataFetch({ params, searchParams }: CalendarPageProps) {
 
   const queryClient = getQueryClient();
   await queryClient.prefetchQuery({
-    queryKey: calendarEventKeys.lists(year, month),
+    queryKey: calendarEventKeys.lists(org.id, year, month),
     queryFn: () => getCachedCalendarEvents(year, month, org.id),
   });
 
   const events =
-    queryClient.getQueryData<CalendarEvent[]>(calendarEventKeys.lists(year, month)) ?? [];
+    queryClient.getQueryData<CalendarEvent[]>(calendarEventKeys.lists(org.id, year, month)) ?? [];
   await Promise.all(
     events.flatMap((event) => [
       queryClient.prefetchQuery({

--- a/apps/assassin/src/app/org/[orgSlug]/calendar/page.tsx
+++ b/apps/assassin/src/app/org/[orgSlug]/calendar/page.tsx
@@ -9,24 +9,32 @@ import { getRsvpAttendeesAction, getUserRsvpStatusAction } from "@features/rsvp/
 import { rsvpKeys } from "@features/rsvp/queries/keys";
 import { getSongsByEventAction } from "@features/eventSong/actions";
 import { eventSongKeys } from "@features/eventSong/queries/keys";
+import { getOrgBySlugAction } from "@features/org/actions";
 import { getQueryClient } from "@libs/react-query/getQueryClient";
 import { CALENDAR_CACHE_TAG } from "@libs/cache/calendar";
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
+import { notFound } from "next/navigation";
 
 interface CalendarPageProps {
+  params: Promise<{ orgSlug: string }>;
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 }
 
-async function getCachedCalendarEvents(year: number, month: number) {
+async function getCachedCalendarEvents(year: number, month: number, orgId: string) {
   "use cache";
   cacheTag(CALENDAR_CACHE_TAG);
   cacheLife("max");
-  return getCalendarEventsByMonthAction(year, month);
+  return getCalendarEventsByMonthAction(year, month, orgId);
 }
 
-async function CalendarDataFetch({ searchParams }: CalendarPageProps) {
-  const params = await searchParams;
-  const dateParam = typeof params.date === "string" ? params.date : undefined;
+async function CalendarDataFetch({ params, searchParams }: CalendarPageProps) {
+  const { orgSlug } = await params;
+  const org = await getOrgBySlugAction(orgSlug).catch(() => null);
+  if (!org) notFound();
+
+  const resolvedSearchParams = await searchParams;
+  const dateParam =
+    typeof resolvedSearchParams.date === "string" ? resolvedSearchParams.date : undefined;
 
   const targetDate = dateParam ? new Date(dateParam) : new Date();
   if (isNaN(targetDate.getTime())) {
@@ -39,7 +47,7 @@ async function CalendarDataFetch({ searchParams }: CalendarPageProps) {
   const queryClient = getQueryClient();
   await queryClient.prefetchQuery({
     queryKey: calendarEventKeys.lists(year, month),
-    queryFn: () => getCachedCalendarEvents(year, month),
+    queryFn: () => getCachedCalendarEvents(year, month, org.id),
   });
 
   const events =
@@ -71,7 +79,7 @@ async function CalendarDataFetch({ searchParams }: CalendarPageProps) {
 export default async function OrgCalendarPage(props: CalendarPageProps) {
   return (
     <Suspense fallback={<CalendarPageSkeleton />}>
-      <CalendarDataFetch searchParams={props.searchParams} />
+      <CalendarDataFetch params={props.params} searchParams={props.searchParams} />
     </Suspense>
   );
 }

--- a/apps/assassin/src/app/org/[orgSlug]/season/page.tsx
+++ b/apps/assassin/src/app/org/[orgSlug]/season/page.tsx
@@ -46,7 +46,7 @@ async function OrgSeasonPageData({ orgId }: { orgId: string }) {
     seasons.map((season) =>
       queryClient.prefetchQuery({
         queryKey: songKeys.bySeason(season.id),
-        queryFn: () => getSongsBySeasonAction(season.id),
+        queryFn: () => getSongsBySeasonAction(season.id, orgId),
       }),
     ),
   );

--- a/apps/assassin/src/app/org/[orgSlug]/season/page.tsx
+++ b/apps/assassin/src/app/org/[orgSlug]/season/page.tsx
@@ -38,7 +38,7 @@ async function OrgSeasonPageData({ orgId }: { orgId: string }) {
 
   const queryClient = getQueryClient();
   const seasons = await queryClient.fetchQuery({
-    queryKey: seasonKeys.lists(),
+    queryKey: seasonKeys.lists(orgId),
     queryFn: () => getSeasonsAction(orgId),
   });
 

--- a/apps/assassin/src/app/org/[orgSlug]/song/[songId]/page.tsx
+++ b/apps/assassin/src/app/org/[orgSlug]/song/[songId]/page.tsx
@@ -60,7 +60,7 @@ async function OrgSongPageContent({ songId, orgId }: { songId: string; orgId: st
     seasons.map((season) =>
       queryClient.prefetchQuery({
         queryKey: songKeys.bySeason(season.id),
-        queryFn: () => getSongsBySeasonAction(season.id),
+        queryFn: () => getSongsBySeasonAction(season.id, orgId),
       }),
     ),
   );

--- a/apps/assassin/src/app/org/[orgSlug]/song/[songId]/page.tsx
+++ b/apps/assassin/src/app/org/[orgSlug]/song/[songId]/page.tsx
@@ -52,7 +52,7 @@ async function OrgSongPageContent({ songId, orgId }: { songId: string; orgId: st
   }
 
   const seasons = await queryClient.fetchQuery({
-    queryKey: seasonKeys.lists(),
+    queryKey: seasonKeys.lists(orgId),
     queryFn: () => getSeasonsAction(orgId),
   });
 

--- a/apps/assassin/src/components/calendar/EventSongAddForm.tsx
+++ b/apps/assassin/src/components/calendar/EventSongAddForm.tsx
@@ -23,7 +23,7 @@ export function EventSongAddForm({ eventId }: { eventId: string }) {
 
   const orgId = useOrgId();
   const { data: seasons = [] } = useQuery({
-    queryKey: seasonKeys.lists(),
+    queryKey: seasonKeys.lists(orgId),
     queryFn: () => getSeasonsAction(orgId),
     staleTime: 1000 * 60,
   });

--- a/apps/assassin/src/components/calendar/EventSongAddForm.tsx
+++ b/apps/assassin/src/components/calendar/EventSongAddForm.tsx
@@ -30,7 +30,7 @@ export function EventSongAddForm({ eventId }: { eventId: string }) {
 
   const { data: songs = [] } = useQuery({
     queryKey: songKeys.bySeason(selectedSeasonId),
-    queryFn: () => getSongsBySeasonAction(selectedSeasonId),
+    queryFn: () => getSongsBySeasonAction(selectedSeasonId, orgId),
     enabled: !!selectedSeasonId,
     staleTime: 1000 * 60,
   });

--- a/apps/assassin/src/components/season/SeasonColumn.tsx
+++ b/apps/assassin/src/components/season/SeasonColumn.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { Season } from "@features/season/schema";
 import type { Song } from "@features/song/schema";
 import { useUpdateSeason } from "@features/season/mutations/useUpdateSeason";
@@ -256,6 +256,7 @@ function SeasonSongListDrag({ seasonId, songs, songCount, onAdd }: SeasonSongLis
 
 function SeasonSongListStatic({ songs, songCount, onAdd }: SeasonSongListProps) {
   const router = useRouter();
+  const params = useParams<{ orgSlug?: string }>();
 
   return (
     <div className="flex-1 min-h-0 overflow-y-auto scrollbar-hidden rounded-md bg-slate-50 dark:bg-slate-900 p-3 sm:p-4">
@@ -264,7 +265,15 @@ function SeasonSongListStatic({ songs, songCount, onAdd }: SeasonSongListProps) 
       ) : (
         <div className="space-y-2">
           {songs.map((song) => (
-            <SongItem key={song.id} song={song} onClick={() => router.push(`/song/${song.id}`)} />
+            <SongItem
+              key={song.id}
+              song={song}
+              onClick={() =>
+                router.push(
+                  params.orgSlug ? `/org/${params.orgSlug}/song/${song.id}` : `/song/${song.id}`,
+                )
+              }
+            />
           ))}
         </div>
       )}

--- a/apps/assassin/src/components/song/SongDetailModal.tsx
+++ b/apps/assassin/src/components/song/SongDetailModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Suspense } from "react";
-import { usePathname } from "next/navigation";
+import { useParams, usePathname } from "next/navigation";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Separator } from "@/components/ui/separator";
 import { Music } from "lucide-react";
@@ -20,6 +20,7 @@ interface SongDetailModalProps {
 
 export function SongDetailModal({ songId, open, onOpenChange }: SongDetailModalProps) {
   const pathname = usePathname();
+  const params = useParams<{ orgSlug?: string }>();
 
   const song = useSong(songId).data;
 
@@ -28,7 +29,8 @@ export function SongDetailModal({ songId, open, onOpenChange }: SongDetailModalP
   }
 
   const youtubeId = extractYoutubeId(song.youtubeUrl);
-  const isActiveRoute = pathname === `/song/${song.id}`;
+  const songRoute = params.orgSlug ? `/org/${params.orgSlug}/song/${song.id}` : `/song/${song.id}`;
+  const isActiveRoute = pathname === songRoute;
   const shouldRenderIframe = Boolean(youtubeId && isActiveRoute);
 
   return (

--- a/apps/assassin/src/components/song/SongDetailPage.tsx
+++ b/apps/assassin/src/components/song/SongDetailPage.tsx
@@ -1,17 +1,20 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { SongDetailModal } from "./SongDetailModal";
 
 export function SongDetailPage({ songId }: { songId: string }) {
   const router = useRouter();
+  const params = useParams<{ orgSlug?: string }>();
 
   return (
     <SongDetailModal
       songId={songId}
       open={true}
       onOpenChange={(isOpen) => {
-        if (!isOpen) router.push("/");
+        if (!isOpen) {
+          router.push(params.orgSlug ? `/org/${params.orgSlug}/season` : "/");
+        }
       }}
     />
   );

--- a/apps/assassin/src/components/song/SortableSongItem.tsx
+++ b/apps/assassin/src/components/song/SortableSongItem.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useSyncExternalStore } from "react";
 import type { CSSProperties } from "react";
-import { useRouter } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import type { Song } from "@features/song/schema";
@@ -20,6 +20,7 @@ export function SortableSongItem({ song }: SortableSongItemProps) {
     () => false,
   );
   const router = useRouter();
+  const params = useParams<{ orgSlug?: string }>();
   const sortable = useSortable({
     id: song.id,
     disabled: !isMounted,
@@ -36,8 +37,9 @@ export function SortableSongItem({ song }: SortableSongItemProps) {
 
   const handleClick = useCallback(() => {
     if (isDragging) return;
-    router.push(`/song/${song.id}`);
-  }, [isDragging, router, song.id]);
+    const songPath = params.orgSlug ? `/org/${params.orgSlug}/song/${song.id}` : `/song/${song.id}`;
+    router.push(songPath);
+  }, [isDragging, params.orgSlug, router, song.id]);
 
   if (!isMounted) {
     return <SongItem song={song} onClick={handleClick} className="cursor-grab" />;

--- a/apps/assassin/src/features/calendar/mutations/useCreateCalendarEvent.ts
+++ b/apps/assassin/src/features/calendar/mutations/useCreateCalendarEvent.ts
@@ -1,18 +1,17 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { createCalendarEventAction } from "../actions";
 import { calendarEventKeys } from "../queries/keys";
-import type { CalendarEvent, CalendarEventPayload } from "../schema";
+import type { CalendarEventPayload } from "../schema";
+import { useOrgId } from "@libs/org/OrgProvider";
 
 export const useCreateCalendarEvent = () => {
   const queryClient = useQueryClient();
+  const orgId = useOrgId();
 
   return useMutation({
-    mutationFn: (data: CalendarEventPayload) => createCalendarEventAction(data),
-    onSuccess: (createdEvent) => {
-      if (!createdEvent) return;
-      queryClient.setQueryData(calendarEventKeys.lists(), (prev: CalendarEvent[] | undefined) =>
-        prev ? [...prev, createdEvent] : [createdEvent],
-      );
+    mutationFn: (data: CalendarEventPayload) => createCalendarEventAction(data, orgId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: calendarEventKeys.all });
     },
   });
 };

--- a/apps/assassin/src/features/calendar/mutations/useDeleteCalendarEvent.ts
+++ b/apps/assassin/src/features/calendar/mutations/useDeleteCalendarEvent.ts
@@ -1,17 +1,16 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { deleteCalendarEventAction } from "../actions";
 import { calendarEventKeys } from "../queries/keys";
-import type { CalendarEvent } from "../schema";
+import { useOrgId } from "@libs/org/OrgProvider";
 
 export const useDeleteCalendarEvent = () => {
   const queryClient = useQueryClient();
+  const orgId = useOrgId();
 
   return useMutation({
-    mutationFn: (id: string) => deleteCalendarEventAction(id),
-    onSuccess: (_, id) => {
-      queryClient.setQueryData(calendarEventKeys.lists(), (prev: CalendarEvent[] | undefined) =>
-        prev ? prev.filter((e) => e.id !== id) : prev,
-      );
+    mutationFn: (id: string) => deleteCalendarEventAction(id, orgId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: calendarEventKeys.all });
     },
   });
 };

--- a/apps/assassin/src/features/calendar/mutations/useUpdateCalendarEvent.ts
+++ b/apps/assassin/src/features/calendar/mutations/useUpdateCalendarEvent.ts
@@ -1,19 +1,18 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { updateCalendarEventAction } from "../actions";
 import { calendarEventKeys } from "../queries/keys";
-import type { CalendarEvent, CalendarEventUpdatePayload } from "../schema";
+import type { CalendarEventUpdatePayload } from "../schema";
+import { useOrgId } from "@libs/org/OrgProvider";
 
 export const useUpdateCalendarEvent = () => {
   const queryClient = useQueryClient();
+  const orgId = useOrgId();
 
   return useMutation({
     mutationFn: ({ id, data }: { id: string; data: CalendarEventUpdatePayload }) =>
-      updateCalendarEventAction(id, data),
-    onSuccess: (updatedEvent) => {
-      if (!updatedEvent) return;
-      queryClient.setQueryData(calendarEventKeys.lists(), (prev: CalendarEvent[] | undefined) =>
-        prev ? prev.map((e) => (e.id === updatedEvent.id ? updatedEvent : e)) : prev,
-      );
+      updateCalendarEventAction(id, orgId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: calendarEventKeys.all });
     },
   });
 };

--- a/apps/assassin/src/features/calendar/queries/keys.ts
+++ b/apps/assassin/src/features/calendar/queries/keys.ts
@@ -1,4 +1,5 @@
 export const calendarEventKeys = {
   all: ["calendarEvents"] as const,
-  lists: (year?: number, month?: number) => [...calendarEventKeys.all, "list", { year, month }] as const,
+  lists: (orgId: string, year?: number, month?: number) =>
+    [...calendarEventKeys.all, "list", { orgId, year, month }] as const,
 };

--- a/apps/assassin/src/features/calendar/queries/useCalendarEvents.ts
+++ b/apps/assassin/src/features/calendar/queries/useCalendarEvents.ts
@@ -7,7 +7,7 @@ import { useOrgId } from "@libs/org/OrgProvider";
 export const useCalendarEvents = (year: number, month: number) => {
   const orgId = useOrgId();
   return useSuspenseQuery({
-    queryKey: calendarEventKeys.lists(year, month),
+    queryKey: calendarEventKeys.lists(orgId, year, month),
     queryFn: () => getCalendarEventsByMonthAction(year, month, orgId),
     select: (data: CalendarEvent[]) =>
       [...data].sort((a, b) => {

--- a/apps/assassin/src/features/calendar/queries/useCalendarEvents.ts
+++ b/apps/assassin/src/features/calendar/queries/useCalendarEvents.ts
@@ -2,11 +2,13 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { getCalendarEventsByMonthAction } from "../actions";
 import { calendarEventKeys } from "./keys";
 import type { CalendarEvent } from "../schema";
+import { useOrgId } from "@libs/org/OrgProvider";
 
 export const useCalendarEvents = (year: number, month: number) => {
+  const orgId = useOrgId();
   return useSuspenseQuery({
     queryKey: calendarEventKeys.lists(year, month),
-    queryFn: () => getCalendarEventsByMonthAction(year, month),
+    queryFn: () => getCalendarEventsByMonthAction(year, month, orgId),
     select: (data: CalendarEvent[]) =>
       [...data].sort((a, b) => {
         const timeDiff = new Date(a.startDate).getTime() - new Date(b.startDate).getTime();

--- a/apps/assassin/src/features/org/repository.ts
+++ b/apps/assassin/src/features/org/repository.ts
@@ -100,10 +100,7 @@ async function getPendingInvitationsByOrg(orgId: string) {
   });
 }
 
-async function updateInvitationStatus(
-  id: string,
-  status: "ACCEPTED" | "EXPIRED" | "CANCELLED",
-) {
+async function updateInvitationStatus(id: string, status: "ACCEPTED" | "EXPIRED" | "CANCELLED") {
   return await prisma.orgInvitation.update({
     where: { id },
     data: { status },

--- a/apps/assassin/src/features/org/schema.ts
+++ b/apps/assassin/src/features/org/schema.ts
@@ -1,16 +1,24 @@
 import { z } from "zod";
 
 export const orgSchema = z.object({
-  id: z.string().uuid(),
+  id: z.uuid(),
   name: z.string().min(1).max(100),
-  slug: z.string().min(1).max(50).regex(/^[a-z0-9-]+$/, "slug는 소문자, 숫자, 하이픈만 허용"),
+  slug: z
+    .string()
+    .min(1)
+    .max(50)
+    .regex(/^[a-z0-9-]+$/, "slug는 소문자, 숫자, 하이픈만 허용"),
   createdAt: z.date(),
   updatedAt: z.date(),
 });
 
 export const createOrgSchema = z.object({
   name: z.string().min(1).max(100),
-  slug: z.string().min(1).max(50).regex(/^[a-z0-9-]+$/, "slug는 소문자, 숫자, 하이픈만 허용"),
+  slug: z
+    .string()
+    .min(1)
+    .max(50)
+    .regex(/^[a-z0-9-]+$/, "slug는 소문자, 숫자, 하이픈만 허용"),
 });
 
 export const updateOrgSchema = z.object({
@@ -18,18 +26,18 @@ export const updateOrgSchema = z.object({
 });
 
 export const orgMemberSchema = z.object({
-  id: z.string().uuid(),
-  orgId: z.string().uuid(),
-  userId: z.string().uuid(),
+  id: z.uuid(),
+  orgId: z.uuid(),
+  userId: z.uuid(),
   role: z.enum(["OWNER", "ADMIN", "MEMBER"]),
   createdAt: z.date(),
   updatedAt: z.date(),
 });
 
 export const orgInvitationSchema = z.object({
-  id: z.string().uuid(),
-  orgId: z.string().uuid(),
-  email: z.string().email(),
+  id: z.uuid(),
+  orgId: z.uuid(),
+  email: z.email(),
   token: z.string(),
   role: z.enum(["OWNER", "ADMIN", "MEMBER"]),
   status: z.enum(["PENDING", "ACCEPTED", "EXPIRED", "CANCELLED"]),
@@ -39,7 +47,7 @@ export const orgInvitationSchema = z.object({
 });
 
 export const inviteMemberSchema = z.object({
-  email: z.string().email(),
+  email: z.email(),
   role: z.enum(["ADMIN", "MEMBER"]).default("MEMBER"),
 });
 

--- a/apps/assassin/src/features/org/service.ts
+++ b/apps/assassin/src/features/org/service.ts
@@ -42,11 +42,7 @@ const getOrgMembers = async (orgId: string, requesterId: string) => {
   return await OrgRepository.getOrgMembers(orgId);
 };
 
-const inviteMember = async (
-  orgId: string,
-  requesterId: string,
-  input: InviteMemberPayload,
-) => {
+const inviteMember = async (orgId: string, requesterId: string, input: InviteMemberPayload) => {
   await assertOrgMember(requesterId, orgId, "ADMIN");
   return await OrgRepository.createInvitation(orgId, input.email, input.role);
 };

--- a/apps/assassin/src/features/season/hooks/useRealtimeSeasonSync.ts
+++ b/apps/assassin/src/features/season/hooks/useRealtimeSeasonSync.ts
@@ -3,9 +3,11 @@ import { useQueryClient } from "@tanstack/react-query";
 import type { Season } from "@features/season/schema";
 import { seasonKeys } from "@features/season/queries/keys";
 import { createBrowserSupabaseClient } from "@/libs/supabase/client";
+import { useOrgId } from "@libs/org/OrgProvider";
 
 export const useRealtimeSeasonSync = () => {
   const queryClient = useQueryClient();
+  const orgId = useOrgId();
 
   const supabase = useMemo(() => createBrowserSupabaseClient(), []);
 
@@ -18,7 +20,7 @@ export const useRealtimeSeasonSync = () => {
         if (eventType === "DELETE") {
           const deletedId = (payload.old as Season | undefined)?.id;
           if (!deletedId) return;
-          queryClient.setQueryData(seasonKeys.lists(), (prev: Season[] | undefined) =>
+          queryClient.setQueryData(seasonKeys.lists(orgId), (prev: Season[] | undefined) =>
             prev ? prev.filter((season) => season.id !== deletedId) : prev,
           );
           queryClient.removeQueries({ queryKey: seasonKeys.detail(deletedId) });
@@ -29,7 +31,7 @@ export const useRealtimeSeasonSync = () => {
         if (!nextSeason) return;
 
         if (eventType === "INSERT") {
-          queryClient.setQueryData(seasonKeys.lists(), (prev: Season[] | undefined) =>
+          queryClient.setQueryData(seasonKeys.lists(orgId), (prev: Season[] | undefined) =>
             prev ? [...prev, nextSeason] : [nextSeason],
           );
           queryClient.setQueryData(seasonKeys.detail(nextSeason.id), nextSeason);
@@ -37,7 +39,7 @@ export const useRealtimeSeasonSync = () => {
         }
 
         // UPDATE
-        queryClient.setQueryData(seasonKeys.lists(), (prev: Season[] | undefined) => {
+        queryClient.setQueryData(seasonKeys.lists(orgId), (prev: Season[] | undefined) => {
           if (!prev) return prev;
           return prev.map((season) =>
             season.id === nextSeason.id ? { ...season, ...nextSeason } : season,
@@ -50,5 +52,5 @@ export const useRealtimeSeasonSync = () => {
     return () => {
       supabase.removeChannel(seasonsChannel);
     };
-  }, [queryClient, supabase]);
+  }, [orgId, queryClient, supabase]);
 };

--- a/apps/assassin/src/features/season/mutations/useCreateSeason.ts
+++ b/apps/assassin/src/features/season/mutations/useCreateSeason.ts
@@ -2,9 +2,11 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { createSeasonAction } from "../actions";
 import { seasonKeys } from "../queries/keys";
 import type { Season, SeasonPayload } from "../schema";
+import { useOrgId } from "@libs/org/OrgProvider";
 
 export const useCreateSeason = () => {
   const queryClient = useQueryClient();
+  const orgId = useOrgId();
 
   return useMutation({
     mutationFn: (data: SeasonPayload) => createSeasonAction(data),
@@ -13,7 +15,7 @@ export const useCreateSeason = () => {
 
       queryClient.setQueryData(seasonKeys.detail(createdSeason.id), createdSeason);
 
-      queryClient.setQueryData(seasonKeys.lists(), (prev: Season[] | undefined) => {
+      queryClient.setQueryData(seasonKeys.lists(orgId), (prev: Season[] | undefined) => {
         if (!prev) return [createdSeason];
         return [...prev, createdSeason];
       });

--- a/apps/assassin/src/features/season/mutations/useCreateSeason.ts
+++ b/apps/assassin/src/features/season/mutations/useCreateSeason.ts
@@ -2,18 +2,20 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { createSeasonAction } from "../actions";
 import { seasonKeys } from "../queries/keys";
 import type { Season, SeasonPayload } from "../schema";
+import { useOrgId } from "@libs/org/OrgProvider";
 
 export const useCreateSeason = () => {
   const queryClient = useQueryClient();
+  const orgId = useOrgId();
 
   return useMutation({
-    mutationFn: (data: SeasonPayload) => createSeasonAction(data),
+    mutationFn: (data: SeasonPayload) => createSeasonAction(data, orgId),
     onSuccess: (createdSeason) => {
       if (!createdSeason) return;
 
       queryClient.setQueryData(seasonKeys.detail(createdSeason.id), createdSeason);
 
-      queryClient.setQueryData(seasonKeys.lists(), (prev: Season[] | undefined) => {
+      queryClient.setQueryData(seasonKeys.lists(orgId), (prev: Season[] | undefined) => {
         if (!prev) return [createdSeason];
         return [...prev, createdSeason];
       });

--- a/apps/assassin/src/features/season/mutations/useUpdateSeason.ts
+++ b/apps/assassin/src/features/season/mutations/useUpdateSeason.ts
@@ -2,9 +2,11 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { updateSeasonAction } from "../actions";
 import { seasonKeys } from "../queries/keys";
 import type { Season, SeasonUpdatePayload } from "../schema";
+import { useOrgId } from "@libs/org/OrgProvider";
 
 export const useUpdateSeason = () => {
   const queryClient = useQueryClient();
+  const orgId = useOrgId();
 
   return useMutation({
     mutationFn: ({ id, data }: { id: string; data: SeasonUpdatePayload }) =>
@@ -14,7 +16,7 @@ export const useUpdateSeason = () => {
 
       queryClient.setQueryData(seasonKeys.detail(updatedSeason.id), updatedSeason);
 
-      queryClient.setQueryData(seasonKeys.lists(), (prev: Season[] | undefined) => {
+      queryClient.setQueryData(seasonKeys.lists(orgId), (prev: Season[] | undefined) => {
         if (!prev) return [updatedSeason];
         const exists = prev.some((season) => season.id === updatedSeason.id);
         if (!exists) return [...prev, updatedSeason];

--- a/apps/assassin/src/features/season/mutations/useUpdateSeason.ts
+++ b/apps/assassin/src/features/season/mutations/useUpdateSeason.ts
@@ -2,19 +2,21 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { updateSeasonAction } from "../actions";
 import { seasonKeys } from "../queries/keys";
 import type { Season, SeasonUpdatePayload } from "../schema";
+import { useOrgId } from "@libs/org/OrgProvider";
 
 export const useUpdateSeason = () => {
   const queryClient = useQueryClient();
+  const orgId = useOrgId();
 
   return useMutation({
     mutationFn: ({ id, data }: { id: string; data: SeasonUpdatePayload }) =>
-      updateSeasonAction(id, data),
+      updateSeasonAction(id, orgId, data),
     onSuccess: (updatedSeason) => {
       if (!updatedSeason) return;
 
       queryClient.setQueryData(seasonKeys.detail(updatedSeason.id), updatedSeason);
 
-      queryClient.setQueryData(seasonKeys.lists(), (prev: Season[] | undefined) => {
+      queryClient.setQueryData(seasonKeys.lists(orgId), (prev: Season[] | undefined) => {
         if (!prev) return [updatedSeason];
         const exists = prev.some((season) => season.id === updatedSeason.id);
         if (!exists) return [...prev, updatedSeason];

--- a/apps/assassin/src/features/season/queries/keys.ts
+++ b/apps/assassin/src/features/season/queries/keys.ts
@@ -1,5 +1,5 @@
 export const seasonKeys = {
   all: ["seasons"] as const,
-  lists: () => [...seasonKeys.all, "list"] as const,
+  lists: (orgId: string) => [...seasonKeys.all, "list", { orgId }] as const,
   detail: (id: string) => [...seasonKeys.all, "detail", id] as const,
 };

--- a/apps/assassin/src/features/season/queries/useSeason.ts
+++ b/apps/assassin/src/features/season/queries/useSeason.ts
@@ -1,10 +1,13 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { getSeasonAction } from "../actions";
 import { seasonKeys } from "./keys";
+import { useOrgId } from "@libs/org/OrgProvider";
 
 export const useSeason = (id: string) => {
+  const orgId = useOrgId();
+
   return useSuspenseQuery({
     queryKey: seasonKeys.detail(id),
-    queryFn: () => getSeasonAction(id),
+    queryFn: () => getSeasonAction(id, orgId),
   });
 };

--- a/apps/assassin/src/features/season/queries/useSeasons.ts
+++ b/apps/assassin/src/features/season/queries/useSeasons.ts
@@ -6,7 +6,7 @@ import { useOrgId } from "@libs/org/OrgProvider";
 export const useSeasons = () => {
   const orgId = useOrgId();
   return useSuspenseQuery({
-    queryKey: seasonKeys.lists(),
+    queryKey: seasonKeys.lists(orgId),
     queryFn: () => getSeasonsAction(orgId),
   });
 };

--- a/apps/assassin/src/features/song/actions.ts
+++ b/apps/assassin/src/features/song/actions.ts
@@ -10,11 +10,11 @@ export const getSongAction = async (id: string) => {
   return await SongService.getSongById(id);
 };
 
-export const getSongsBySeasonAction = async (seasonId: string) => {
-  return await SongService.getSongsBySeasonId(seasonId);
+export const getSongsBySeasonAction = async (seasonId: string, orgId: string) => {
+  return await SongService.getSongsBySeasonId(seasonId, orgId);
 };
 
-export const createSongAction = async (data: {
+export const createSongAction = async (orgId: string, data: {
   seasonId: string;
   name: string;
   artist: string;
@@ -23,7 +23,7 @@ export const createSongAction = async (data: {
   sortOrder: number;
 }) => {
   const user = await getCurrentUser();
-  const result = await SongService.createSong({ ...data, userId: user.id });
+  const result = await SongService.createSong({ ...data, userId: user.id }, orgId);
   revalidateSeasonBoard();
   return result;
 };

--- a/apps/assassin/src/features/song/mutations/useCreateSong.ts
+++ b/apps/assassin/src/features/song/mutations/useCreateSong.ts
@@ -3,12 +3,14 @@ import { createSongAction } from "../actions";
 import { songKeys } from "../queries/keys";
 import type { SongFormData } from "../hooks/useSongForm";
 import type { Song } from "../schema";
+import { useOrgId } from "@libs/org/OrgProvider";
 
 export const useCreateSong = () => {
   const queryClient = useQueryClient();
+  const orgId = useOrgId();
 
   return useMutation({
-    mutationFn: (data: SongFormData) => createSongAction(data),
+    mutationFn: (data: SongFormData) => createSongAction(orgId, data),
     onSuccess: (createdSong) => {
       if (!createdSong) return;
       queryClient.setQueryData(songKeys.detail(createdSong.id), createdSong);

--- a/apps/assassin/src/features/song/queries/useSongsBySeason.ts
+++ b/apps/assassin/src/features/song/queries/useSongsBySeason.ts
@@ -1,10 +1,13 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { getSongsBySeasonAction } from "../actions";
 import { songKeys } from "./keys";
+import { useOrgId } from "@libs/org/OrgProvider";
 
 export const useSongsBySeason = (seasonId: string) => {
+  const orgId = useOrgId();
+
   return useSuspenseQuery({
     queryKey: songKeys.bySeason(seasonId),
-    queryFn: () => getSongsBySeasonAction(seasonId),
+    queryFn: () => getSongsBySeasonAction(seasonId, orgId),
   });
 };

--- a/apps/assassin/src/features/song/service.ts
+++ b/apps/assassin/src/features/song/service.ts
@@ -19,8 +19,8 @@ const assertSongExists = async (songId: string): Promise<void> => {
   }
 };
 
-const createSong = async (song: SongPayload) => {
-  await SeasonService.assertSeasonExists(song.seasonId);
+const createSong = async (song: SongPayload, orgId: string) => {
+  await SeasonService.assertSeasonExists(song.seasonId, orgId);
 
   let result;
   try {
@@ -70,8 +70,8 @@ const getSongById = async (id: string): Promise<Song | null> => {
   return parsed.data;
 };
 
-const getSongsBySeasonId = async (seasonId: string): Promise<Array<Song>> => {
-  await SeasonService.assertSeasonExists(seasonId);
+const getSongsBySeasonId = async (seasonId: string, orgId: string): Promise<Array<Song>> => {
+  await SeasonService.assertSeasonExists(seasonId, orgId);
 
   const songs = await SongRepository.getSongsBySeasonId(seasonId);
 

--- a/apps/assassin/src/libs/org/OrgProvider.tsx
+++ b/apps/assassin/src/libs/org/OrgProvider.tsx
@@ -4,13 +4,7 @@ import { createContext, useContext } from "react";
 
 const OrgContext = createContext<{ orgId: string }>({ orgId: "" });
 
-export function OrgProvider({
-  orgId,
-  children,
-}: {
-  orgId: string;
-  children: React.ReactNode;
-}) {
+export function OrgProvider({ orgId, children }: { orgId: string; children: React.ReactNode }) {
   return <OrgContext.Provider value={{ orgId }}>{children}</OrgContext.Provider>;
 }
 

--- a/apps/assassin/src/libs/org/OrgProvider.tsx
+++ b/apps/assassin/src/libs/org/OrgProvider.tsx
@@ -2,12 +2,18 @@
 
 import { createContext, useContext } from "react";
 
-const OrgContext = createContext<{ orgId: string }>({ orgId: "" });
+const OrgContext = createContext<{ orgId: string } | null>(null);
 
 export function OrgProvider({ orgId, children }: { orgId: string; children: React.ReactNode }) {
   return <OrgContext.Provider value={{ orgId }}>{children}</OrgContext.Provider>;
 }
 
 export function useOrgId(): string {
-  return useContext(OrgContext).orgId;
+  const context = useContext(OrgContext);
+
+  if (!context) {
+    throw new Error("useOrgId must be used within OrgProvider");
+  }
+
+  return context.orgId;
 }


### PR DESCRIPTION

   ## 개요
   
   `org` 테이블 도입 이후 발생한 빌드 에러 및 데이터 범위 문제를 수정합니다.
   전 영역(캘린더, 시즌, 곡)에서 `orgId`를 기준으로 쿼리·뮤테이션·라우팅을 
  통일하고,
   `OrgProvider` 사용 방식을 명확히 했습니다.
   
   ## 변경 사항
   
   ### 🔧 버그 수정
   - `song`, `season`, `calendar` 뮤테이션에 `orgId` 누락 전달 수정
   - `OrgProvider`에 안전 가드 추가 (orgId 없을 시 fallback 처리)
   - `repository` 반환 타입 복원 및 `orgId` 흐름 강제 적용
   
   ### ♻️ 리팩터링
   - `season` / `calendar` 쿼리 키를 `orgId` 기준으로 네임스페이스 분리
   - 곡 관련 라우팅을 `/org/[orgSlug]/song/...` 경로로 통일
   - `inviteMember` 함수 시그니처 단순화 및 `org` 스키마 타입 정비
   
   ### ✨ 기능 개선
   - 캘린더에 조직 컨텍스트 반영 및 이벤트 뮤테이션 개선
   
   ## 영향 범위
   
   `apps/assassin` — calendar, season, song, org 도메인 전반
   
   ## 완료 조건
   
   - [x] orgId 없이 쿼리/뮤테이션 호출되는 경로 없음
   - [x] 곡 라우팅이 org slug 경로 아래로 통일됨
   - [x] 빌드 에러 없음