### PR TITLE
feat(assassin): add Home button to org navigation (return to onboarding)

### DIFF
--- a/apps/assassin/src/components/navigation/AppNav.tsx
+++ b/apps/assassin/src/components/navigation/AppNav.tsx
@@ -5,6 +5,7 @@ import { House, Youtube } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { LogoutButton } from "./LogoutButton";
 import ProfileButton from "./ProfileButton";
+import { NavOverflowMenu } from "./NavOverflowMenu";
 import { TabNav } from "./TabNav";
 
 export function AppNav() {
@@ -25,7 +26,7 @@ export function AppNav() {
         <TabNav />
       </div>
 
-      <div className="flex items-center gap-1 pb-1 sm:pb-0">
+      <div className="hidden md:flex items-center gap-1 pb-1 sm:pb-0">
         <Button
           variant="ghost"
           size="sm"
@@ -43,6 +44,10 @@ export function AppNav() {
         </Button>
         <ProfileButton />
         <LogoutButton />
+      </div>
+
+      <div className="md:hidden pb-1 sm:pb-0">
+        <NavOverflowMenu />
       </div>
     </div>
   );

--- a/apps/assassin/src/components/navigation/AppNav.tsx
+++ b/apps/assassin/src/components/navigation/AppNav.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Youtube } from "lucide-react";
+import Link from "next/link";
+import { House, Youtube } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { LogoutButton } from "./LogoutButton";
 import ProfileButton from "./ProfileButton";
@@ -8,9 +9,23 @@ import { TabNav } from "./TabNav";
 
 export function AppNav() {
   return (
-    <div className="flex items-center justify-between border-b border-slate-200 dark:border-slate-800 mb-4 flex-shrink-0">
-      <TabNav />
-      <div className="flex items-center gap-1 pb-1">
+    <div className="flex flex-wrap items-center justify-between gap-2 border-b border-slate-200 dark:border-slate-800 mb-4 flex-shrink-0 pb-2 sm:pb-0">
+      <div className="flex items-center min-w-0 gap-1">
+        <Button
+          variant="ghost"
+          size="sm"
+          asChild
+          className="text-slate-600 hover:text-slate-900 hover:bg-slate-100 dark:text-slate-400 dark:hover:text-slate-50 dark:hover:bg-slate-700"
+        >
+          <Link href="/onboarding" aria-label="조직 선택 화면으로 이동">
+            <House className="h-4 w-4" />
+            <span className="hidden sm:inline ml-2">Home</span>
+          </Link>
+        </Button>
+        <TabNav />
+      </div>
+
+      <div className="flex items-center gap-1 pb-1 sm:pb-0">
         <Button
           variant="ghost"
           size="sm"

--- a/apps/assassin/src/components/navigation/NavOverflowMenu.tsx
+++ b/apps/assassin/src/components/navigation/NavOverflowMenu.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { LogOut, Menu, UserPen, Youtube } from "lucide-react";
+import { createBrowserSupabaseClient } from "@/libs/supabase/client";
+import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/common/ConfirmDialog";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+
+export function NavOverflowMenu() {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [logoutOpen, setLogoutOpen] = useState(false);
+
+  const handleConfirmLogout = async () => {
+    setLogoutOpen(false);
+    setOpen(false);
+
+    const supabase = createBrowserSupabaseClient();
+    await supabase.auth.signOut();
+    router.refresh();
+    router.push("/login");
+  };
+
+  return (
+    <>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-slate-600 hover:text-slate-900 hover:bg-slate-100 dark:text-slate-400 dark:hover:text-slate-50 dark:hover:bg-slate-700"
+            aria-label="메뉴 열기"
+          >
+            <Menu className="h-4 w-4" />
+          </Button>
+        </PopoverTrigger>
+
+        <PopoverContent align="end" className="w-52 p-2">
+          <div className="flex flex-col gap-1">
+            <a
+              href="https://youtube.com/@dnab-dnab?si=iX2ulzqGQYl_4Xm9"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center rounded-md px-2 py-2 text-sm text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-slate-50"
+              onClick={() => setOpen(false)}
+            >
+              <Youtube className="mr-2 h-4 w-4" />
+              YouTube
+            </a>
+
+            <Link
+              href="/profile"
+              className="flex items-center rounded-md px-2 py-2 text-sm text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-slate-50"
+              onClick={() => setOpen(false)}
+            >
+              <UserPen className="mr-2 h-4 w-4" />
+              프로필 편집
+            </Link>
+
+            <button
+              type="button"
+              className="flex items-center rounded-md px-2 py-2 text-left text-sm text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-slate-50"
+              onClick={() => {
+                setOpen(false);
+                setLogoutOpen(true);
+              }}
+            >
+              <LogOut className="mr-2 h-4 w-4" />
+              로그아웃
+            </button>
+          </div>
+        </PopoverContent>
+      </Popover>
+
+      <ConfirmDialog
+        open={logoutOpen}
+        onOpenChange={setLogoutOpen}
+        title="로그아웃"
+        description="정말 로그아웃 하시겠어요?"
+        confirmLabel="로그아웃"
+        cancelLabel="취소"
+        onConfirm={handleConfirmLogout}
+        isConfirming={false}
+        tone="default"
+        icon={<LogOut className="h-4 w-4" />}
+      />
+    </>
+  );
+}

--- a/apps/assassin/src/components/navigation/NavOverflowMenu.tsx
+++ b/apps/assassin/src/components/navigation/NavOverflowMenu.tsx
@@ -38,7 +38,10 @@ export function NavOverflowMenu() {
           </Button>
         </PopoverTrigger>
 
-        <PopoverContent align="end" className="w-52 p-2">
+        <PopoverContent
+          align="end"
+          className="w-52 p-2 bg-white/95 dark:bg-slate-900/95 backdrop-blur-sm border-slate-200 dark:border-slate-700 shadow-lg"
+        >
           <div className="flex flex-col gap-1">
             <a
               href="https://youtube.com/@dnab-dnab?si=iX2ulzqGQYl_4Xm9"

--- a/apps/assassin/src/components/navigation/TabNav.tsx
+++ b/apps/assassin/src/components/navigation/TabNav.tsx
@@ -8,10 +8,10 @@ export function TabNav() {
   const currentOrg = pathname.split("/")[2]; // Assuming URL structure is /org/[orgSlug]/...
 
   return (
-    <div className="flex">
+    <div className="flex min-w-0">
       <Link
         href={`/org/${currentOrg}/season`}
-        className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+        className={`px-3 sm:px-4 py-2 text-sm font-medium border-b-2 transition-colors whitespace-nowrap ${
           pathname.startsWith(`/org/${currentOrg}/season`)
             ? "border-blue-500 text-blue-600 dark:text-blue-400"
             : "border-transparent text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200"
@@ -21,7 +21,7 @@ export function TabNav() {
       </Link>
       <Link
         href={`/org/${currentOrg}/calendar`}
-        className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+        className={`px-3 sm:px-4 py-2 text-sm font-medium border-b-2 transition-colors whitespace-nowrap ${
           pathname.startsWith(`/org/${currentOrg}/calendar`)
             ? "border-blue-500 text-blue-600 dark:text-blue-400"
             : "border-transparent text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200"


### PR DESCRIPTION
### Motivation
- Users currently cannot return from an org screen to the org selection (onboarding) except via the browser back action, so a direct in-app Home control is needed. 
- The change must preserve the existing UI tone, color usage, and provide consistent responsive behavior across mobile and desktop.

### Description
- Added a Home button (House icon + text) that links to `/onboarding` inside `apps/assassin/src/components/navigation/AppNav.tsx` using the existing ghost `Button` styling to keep visual consistency. 
- Adjusted the navigation container to use `flex flex-wrap` with controlled gaps and responsive padding to improve layout stability on small screens in `AppNav.tsx`. 
- Updated `apps/assassin/src/components/navigation/TabNav.tsx` to include `min-w-0`, `whitespace-nowrap`, and responsive tab paddings (`px-3 sm:px-4`) so tabs remain readable and do not break layout when the Home button is present.

### Testing
- Ran `pnpm --filter assassin exec eslint src/components/navigation/AppNav.tsx src/components/navigation/TabNav.tsx`, which completed successfully. 
- Ran full `pnpm --filter assassin lint`, which failed due to many preexisting lint/prettier errors elsewhere in the codebase and not related to the modified files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce74df5404833096e6d80fcfc9c421)