### PR TITLE
feat(ymm): add selectable Claude/Codex agents for Discord bot

### DIFF
--- a/apps/ymm/README.md
+++ b/apps/ymm/README.md
@@ -1,15 +1,16 @@
 # ymm
 
-Discord 채널에서 Claude Code CLI를 원격으로 실행할 수 있는 Discord 봇입니다.
+Discord 채널에서 Claude Code CLI 또는 Codex CLI를 선택해서 원격 실행할 수 있는 Discord 봇입니다.
 
 ## 개요
 
-Discord 메시지로 프롬프트를 보내면, 봇이 지정한 프로젝트 루트 경로에서 Claude Code를 실행하고 결과를 채널로 전송합니다. 세션 유지 기능을 통해 대화 맥락을 이어가며 작업할 수 있습니다.
+Discord 메시지로 프롬프트를 보내면, 봇이 지정한 프로젝트 루트 경로에서 선택한 에이전트(Claude/Codex)를 실행하고 결과를 채널로 전송합니다. Claude 사용 시 세션 유지 기능으로 대화 맥락을 이어갈 수 있습니다.
 
 ## 사전 요구사항
 
 - [Node.js](https://nodejs.org/) v20 이상
 - [Claude Code CLI](https://docs.anthropic.com/ko/docs/claude-code) (`claude` 명령어가 PATH에 등록되어 있어야 함)
+- Codex CLI (`codex` 명령어가 PATH에 등록되어 있어야 함)
 - Discord Bot Token ([Discord Developer Portal](https://discord.com/developers/applications)에서 발급)
 
 ## 설치
@@ -31,6 +32,7 @@ cp .env.example .env
 | `DISCORD_TOKEN` | ✅ | Discord Bot Token |
 | `ALLOWED_CHANNEL_IDS` | - | 봇이 응답할 채널 ID (쉼표로 구분). 미설정 시 모든 채널에서 응답 |
 | `PROJECT_ROOT` | - | Claude Code가 실행될 프로젝트 루트 경로. 미설정 시 자동 감지 |
+| `CODEX_BIN` | - | Codex CLI 실행 파일 이름 또는 경로 (기본값: `codex`) |
 
 ## 실행
 
@@ -64,6 +66,7 @@ npm start
 | `!done` | 현재 채널의 세션을 초기화합니다 |
 | `!stop` | 실행 중인 작업을 강제 종료하고 세션을 초기화합니다 |
 | `!session` | 현재 활성 세션 ID를 확인합니다 |
+| `!agent` | 현재 채널의 에이전트를 확인하거나 변경합니다 (`!agent claude`, `!agent codex`) |
 | `!cost` | Claude Code 세션의 토큰 사용량을 확인합니다 |
 | `#숫자` | GitHub 이슈 번호로 Claude Code 작업을 시작합니다 (예: `#42`) |
 | `team N:작업` | N개 워커로 멀티 에이전트 병렬 실행합니다 (예: `team 3:버튼 리팩터`) |
@@ -86,6 +89,16 @@ team 2:#42
 
 채널별로 세션이 유지되어 같은 채널에서 연속된 대화 맥락으로 작업할 수 있습니다. `!done` 명령으로 세션을 초기화하면 다음 메시지부터 새 작업으로 시작합니다.
 
+에이전트는 채널별로 선택할 수 있습니다.
+
+```
+!agent codex
+!agent claude
+```
+
+- 기본값은 `claude`입니다.
+- `!cost`는 Claude 에이전트에서만 동작합니다.
+
 ## Claude Code 허용 도구
 
 보안상 다음 도구만 사용하도록 제한되어 있습니다.
@@ -105,9 +118,12 @@ src/
 ├── claude/
 │   ├── runner.ts             # Claude Code CLI 실행 및 스트림 처리
 │   └── formatter.ts          # 도구 입력/결과 포맷팅
+├── codex/
+│   └── runner.ts             # Codex CLI 실행
 └── discord/
     ├── bot.ts                # Discord 클라이언트 및 메시지 이벤트
     ├── attachments.ts        # 첨부파일 다운로드 및 프롬프트 빌드
+    ├── agentStore.ts         # 채널별 에이전트(Claude/Codex) 관리
     ├── discordLogger.ts      # Discord 채널로 버퍼링하여 로그 전송
     └── sessionStore.ts       # 채널별 세션 ID 관리
 ```

--- a/apps/ymm/src/codex/runner.ts
+++ b/apps/ymm/src/codex/runner.ts
@@ -1,0 +1,101 @@
+import { Message } from 'discord.js'
+import { spawn } from 'child_process'
+import { c, ts, truncate } from '../utils/ansi.js'
+import { createDiscordLogger } from '../discord/discordLogger.js'
+import { cleanup } from '../discord/attachments.js'
+import { CODEX_BIN, PROJECT_ROOT } from '../config.js'
+
+const WORKFLOW_RULES = `[WORKFLOW RULES]
+
+작업을 시작하기 전에 반드시 다음 절차를 수행해야 한다.
+
+1. dev 브랜치를 checkout 하고 최신 상태로 pull 한다.
+2. claude.md 파일을 읽는다.
+3. claude.md에 정의된 작업 규칙을 요약한다.
+4. 작업 계획을 먼저 작성하고 요약해서 출력한다.
+5. 계획이 완료되기 전에는 코드를 수정하지 않는다.
+
+작업을 완료한 후에는 반드시 다음 절차를 수행해야 한다.
+
+- 테스트 실행
+- 빌드 확인
+- 테스트와 빌드가 모두 성공한 경우에만 PR 생성
+
+이 규칙은 항상 준수해야 한다.
+규칙을 따르지 못하는 경우 작업을 중단하고 이유를 설명해야 한다.
+
+---
+
+`
+
+type SendFn = (content: string) => Promise<unknown>
+
+type RunOptions = {
+  onDone?: () => void
+  logChannel?: { send: SendFn }
+  resultChannel?: { send: SendFn }
+}
+
+export function runCodexCode(
+  prompt: string,
+  message: Message,
+  processingMsg: Message,
+  tempFiles: string[],
+  { onDone, logChannel, resultChannel }: RunOptions = {},
+) {
+  const start = Date.now()
+  const discordLogger = createDiscordLogger(
+    logChannel ?? (message.channel as { send: SendFn }),
+  )
+  const fullPrompt = WORKFLOW_RULES + prompt
+
+  const child = spawn(CODEX_BIN, ['exec', fullPrompt], {
+    cwd: PROJECT_ROOT,
+    env: { ...process.env },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  let output = ''
+  child.stdout.on('data', (chunk: Buffer) => {
+    const text = chunk.toString()
+    output += text
+    discordLogger.log(`🧠 [codex] ${truncate(text, 500)}`)
+  })
+
+  child.stderr.on('data', (chunk: Buffer) => {
+    const text = chunk.toString().trim()
+    if (!text) return
+    console.error(`${ts()} ${c.red}[codex stderr]${c.reset} ${text}`)
+    discordLogger.log(`⚠️ [codex stderr] ${truncate(text, 500)}`)
+  })
+
+  child.on('close', async (code) => {
+    const elapsed = ((Date.now() - start) / 1000).toFixed(1)
+    onDone?.()
+    await cleanup(tempFiles)
+    if (code === 0) {
+      processingMsg.edit('✅ Codex 작업이 완료되었습니다.').catch(() => {})
+      const resultTarget = resultChannel ?? (message.channel as { send: SendFn })
+      const finalText = output.trim() ? truncate(output, 1800) : '✅ Codex 작업이 완료되었습니다.'
+      resultTarget.send(finalText).catch(() => {})
+      discordLogger.log(`✅ Codex 작업 완료 (${elapsed}s)`)
+      discordLogger.forceFlush()
+      return
+    }
+    processingMsg.edit('❌ Codex 작업이 실패했습니다.').catch(() => {})
+    discordLogger.log(`❌ Codex 작업 실패 (${elapsed}s, code=${code ?? 'null'})`)
+    discordLogger.forceFlush()
+  })
+
+  child.on('error', (err) => {
+    const msg = err.message.includes('ENOENT')
+      ? `'${CODEX_BIN}' 명령어를 찾을 수 없습니다. Codex CLI 설치를 확인하세요.`
+      : err.message
+    console.error(`${ts()} ${c.red}[오류]${c.reset} ${msg}`)
+    discordLogger.log(`[오류] ${msg}`)
+    processingMsg.edit(`❌ ${msg}`).catch(() => {})
+    discordLogger.forceFlush()
+  })
+
+  return child
+}

--- a/apps/ymm/src/config.ts
+++ b/apps/ymm/src/config.ts
@@ -7,6 +7,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 export const DISCORD_TOKEN = process.env.DISCORD_TOKEN
 export const PROJECT_ROOT =
   process.env.PROJECT_ROOT ?? path.resolve(__dirname, '../../..')
+export const CODEX_BIN = process.env.CODEX_BIN ?? 'codex'
 
 // 채널별 ID
 export const DISCORD_COMMAND_ID = process.env.DISCORD_COMMAND_ID ?? ''  // 명령/질의응답 채널

--- a/apps/ymm/src/discord/agentStore.ts
+++ b/apps/ymm/src/discord/agentStore.ts
@@ -1,0 +1,11 @@
+export type AgentType = 'claude' | 'codex'
+
+const channelAgents = new Map<string, AgentType>()
+
+export function getAgent(channelId: string): AgentType {
+  return channelAgents.get(channelId) ?? 'claude'
+}
+
+export function setAgent(channelId: string, agent: AgentType) {
+  channelAgents.set(channelId, agent)
+}

--- a/apps/ymm/src/discord/bot.ts
+++ b/apps/ymm/src/discord/bot.ts
@@ -5,13 +5,16 @@ import { downloadAttachments, buildPrompt, cleanup } from './attachments.js'
 import { getSession, setSession, clearSession } from './sessionStore.js'
 import { killProcess, getProcess, setProcess, clearProcess } from './processStore.js'
 import { runClaudeCode } from '../claude/runner.js'
+import { runCodexCode } from '../codex/runner.js'
 import { fetchIssue, buildIssuePrompt, createPR } from '../github/client.js'
 import { splitIntoChunks } from '../utils/ansi.js'
+import { getAgent, setAgent } from './agentStore.js'
 
 const COMMANDS = [
   { name: '!done',         desc: '현재 세션 종료 (다음 메시지부터 새 작업으로 시작)' },
   { name: '!stop',         desc: '실행 중인 작업 강제 종료 + 세션 초기화' },
   { name: '!session',      desc: '현재 활성 세션 ID 확인' },
+  { name: '!agent',        desc: '현재 에이전트 확인 또는 변경 (!agent claude | !agent codex)' },
   { name: '!cost',         desc: 'Claude Code 세션의 토큰 사용량 확인' },
   { name: '#숫자',         desc: 'GitHub 이슈 번호로 Claude Code 작업 시작 (예: #42)' },
   { name: 'team N:작업',  desc: 'N개 워커로 멀티 에이전트 병렬 실행 (예: team 3:버튼 컴포넌트 리팩터)' },
@@ -74,8 +77,24 @@ client.on('messageCreate', async (message: Message) => {
     return
   }
 
+  // !agent — 현재 에이전트 확인 / 변경
+  if (text === '!agent' || text === '!agent claude' || text === '!agent codex') {
+    if (text === '!agent') {
+      await message.reply(`현재 에이전트: **${getAgent(message.channelId)}**`)
+      return
+    }
+    const nextAgent = text.endsWith('codex') ? 'codex' : 'claude'
+    setAgent(message.channelId, nextAgent)
+    await message.reply(`✅ 현재 채널 에이전트가 **${nextAgent}** 로 변경되었습니다.`)
+    return
+  }
+
   // !cost — Claude Code /context 출력
   if (text === '!cost') {
+    if (getAgent(message.channelId) !== 'claude') {
+      await message.reply('ℹ️ `!cost`는 Claude 에이전트에서만 지원됩니다.')
+      return
+    }
     const sid = getSession(message.channelId)
     try {
       const resumeFlag = sid ? `--resume ${sid} ` : ''
@@ -178,7 +197,10 @@ client.on('messageCreate', async (message: Message) => {
   const hasAttachments = message.attachments.size > 0
   if (!text && !hasAttachments) return
 
-  const processingMsg = await message.reply('⏳ Claude Code가 작업 중입니다...')
+  const agent = getAgent(message.channelId)
+  const processingMsg = await message.reply(
+    agent === 'claude' ? '⏳ Claude Code가 작업 중입니다...' : '⏳ Codex가 작업 중입니다...',
+  )
 
   const sessionId = getSession(message.channelId)
 
@@ -186,14 +208,20 @@ client.on('messageCreate', async (message: Message) => {
   try {
     const attachmentPaths = await downloadAttachments(message, tempFiles)
     const prompt = buildPrompt(text, attachmentPaths)
-    const child = runClaudeCode(prompt, message, processingMsg, tempFiles, {
-      sessionId,
-      onSessionId: (id) => setSession(message.channelId, id),
-      onDone: () => clearProcess(message.channelId),
-      logChannel: getTextChannel(DISCORD_LOG_ID),
-      resultChannel: getTextChannel(DISCORD_RESULT_ID),
-      commandChannel: getTextChannel(DISCORD_COMMAND_ID),
-    })
+    const child = agent === 'claude'
+      ? runClaudeCode(prompt, message, processingMsg, tempFiles, {
+          sessionId,
+          onSessionId: (id) => setSession(message.channelId, id),
+          onDone: () => clearProcess(message.channelId),
+          logChannel: getTextChannel(DISCORD_LOG_ID),
+          resultChannel: getTextChannel(DISCORD_RESULT_ID),
+          commandChannel: getTextChannel(DISCORD_COMMAND_ID),
+        })
+      : runCodexCode(prompt, message, processingMsg, tempFiles, {
+          onDone: () => clearProcess(message.channelId),
+          logChannel: getTextChannel(DISCORD_LOG_ID),
+          resultChannel: getTextChannel(DISCORD_RESULT_ID),
+        })
     setProcess(message.channelId, child)
   } catch (err) {
     await processingMsg.edit(`❌ 첨부파일 다운로드 실패: ${(err as Error).message}`)


### PR DESCRIPTION
### Motivation
- Allow users to choose between the existing Claude Code CLI and a new Codex CLI per Discord channel so teams can use whichever agent they prefer.
- Keep existing Claude session behavior while providing a simple opt-in for Codex without changing global behavior.

### Description
- Add a channel-scoped agent store with `getAgent`/`setAgent` in `apps/ymm/src/discord/agentStore.ts` and default to `claude`.
- Implement a Codex runner in `apps/ymm/src/codex/runner.ts` that spawns the Codex CLI, streams logs to the discord logger, and posts results to the result channel.
- Expose `CODEX_BIN` in `apps/ymm/src/config.ts` for configuring the Codex binary name/path (`CODEX_BIN`, default `codex`).
- Update the message handling flow in `apps/ymm/src/discord/bot.ts` to add the `!agent` command, guard `!cost` for Claude-only usage, and branch runtime execution to `runClaudeCode` or `runCodexCode` based on the channel agent.
- Update `apps/ymm/README.md` to document the new `!agent` command, `CODEX_BIN` env var, and the codex runner location.

### Testing
- Ran `pnpm --filter ymm build` which completed successfully and produced a TypeScript build (only an engine warning about Node version was emitted).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4ae8a1d508330a78a8f3fcd1e3d05)