### PR TITLE
feat: 조직 초대 생성 서버 사이드 구현

### DIFF
--- a/apps/assassin/src/features/org/actions.ts
+++ b/apps/assassin/src/features/org/actions.ts
@@ -2,7 +2,12 @@
 
 import { createServerSupabaseClient } from "@libs/supabase/server";
 import OrgService from "./service";
-import { CreateOrgPayload, InviteMemberPayload, UpdateOrgPayload } from "./schema";
+import {
+  CreateOrgPayload,
+  InviteMemberPayload,
+  UpdateOrgPayload,
+  inviteMemberSchema,
+} from "./schema";
 
 async function getCurrentUserId(): Promise<string> {
   const supabase = await createServerSupabaseClient();
@@ -41,9 +46,31 @@ export const getOrgMembersAction = async (orgId: string) => {
   return await OrgService.getOrgMembers(orgId, userId);
 };
 
-export const inviteMemberAction = async (orgId: string, input: InviteMemberPayload) => {
-  const userId = await getCurrentUserId();
-  return await OrgService.inviteMember(orgId, userId, input);
+export const inviteMemberAction = async (
+  orgId: string,
+  input: InviteMemberPayload,
+): Promise<
+  | { success: true; data: { id: string; email: string; expiresAt: Date } }
+  | { success: false; error: string }
+> => {
+  const parsed = inviteMemberSchema.safeParse(input);
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.issues[0].message };
+  }
+
+  try {
+    const userId = await getCurrentUserId();
+    const invitation = await OrgService.inviteMember(orgId, userId, parsed.data);
+    return {
+      success: true,
+      data: { id: invitation.id, email: invitation.email, expiresAt: invitation.expiresAt },
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "초대 생성에 실패했습니다.",
+    };
+  }
 };
 
 export const acceptInvitationAction = async (token: string) => {

--- a/apps/assassin/src/features/org/repository.ts
+++ b/apps/assassin/src/features/org/repository.ts
@@ -107,6 +107,22 @@ async function updateInvitationStatus(id: string, status: "ACCEPTED" | "EXPIRED"
   });
 }
 
+// auth.users는 Prisma 스키마 외부(Supabase Auth 스키마)이므로 raw query 사용
+async function findUserIdByEmail(email: string): Promise<string | null> {
+  const rows = await prisma.$queryRaw<{ id: string }[]>`
+    SELECT id FROM auth.users WHERE email = ${email} LIMIT 1
+  `;
+  return rows[0]?.id ?? null;
+}
+
+// 동일 (orgId, email)의 PENDING 초대를 모두 취소 — 재초대 시 호출
+async function cancelPendingInvitationsByEmail(orgId: string, email: string): Promise<void> {
+  await prisma.orgInvitation.updateMany({
+    where: { orgId, email, status: "PENDING" },
+    data: { status: "CANCELLED" },
+  });
+}
+
 const OrgRepository = {
   getOrgById,
   getOrgBySlug,
@@ -123,6 +139,8 @@ const OrgRepository = {
   getInvitationByToken,
   getPendingInvitationsByOrg,
   updateInvitationStatus,
+  findUserIdByEmail,
+  cancelPendingInvitationsByEmail,
 };
 
 export default OrgRepository;

--- a/apps/assassin/src/features/org/service.ts
+++ b/apps/assassin/src/features/org/service.ts
@@ -44,7 +44,22 @@ const getOrgMembers = async (orgId: string, requesterId: string) => {
 
 const inviteMember = async (orgId: string, requesterId: string, input: InviteMemberPayload) => {
   await assertOrgMember(requesterId, orgId, "OWNER");
-  return await OrgRepository.createInvitation(orgId, input.email, "MEMBER");
+
+  const email = input.email.toLowerCase().trim();
+
+  // 이미 가입된 유저라면 조직 멤버 여부 확인
+  const existingUserId = await OrgRepository.findUserIdByEmail(email);
+  if (existingUserId) {
+    const existingMember = await OrgRepository.getMember(orgId, existingUserId);
+    if (existingMember) {
+      throw new Error("이미 조직의 멤버입니다.");
+    }
+  }
+
+  // 기존 PENDING 초대 취소 후 재생성 (재초대 정책: PENDING → CANCELLED + 신규 생성)
+  await OrgRepository.cancelPendingInvitationsByEmail(orgId, email);
+
+  return await OrgRepository.createInvitation(orgId, email, "MEMBER");
 };
 
 const acceptInvitation = async (token: string, userId: string) => {


### PR DESCRIPTION
  ## 변경 내용                                                                             
                                                                                           
  ### 검증 흐름                          
  1. Zod 입력 검증 (email 형식, role)                                                      
  2. 인증 확인 (getCurrentUserId)                                                          
  3. OWNER 권한 확인 (assertOrgMember)                                                     
  4. 이미 가입된 유저라면 조직 멤버 여부 확인                                              
  5. 기존 PENDING 초대 취소 후 재생성 (재초대 정책)                                        
  6. 초대 생성 (7일 만료)                                                                  
                                                                                           
  ### 완료 조건                                                                            
  - [x] 미인증 요청 거부                                                                   
  - [x] OWNER 아닌 유저 초대 시도 거부                                                     
  - [x] 이미 멤버인 이메일 초대 거부     
  - [x] 중복 PENDING 초대 → 취소 후 재생성                                                 
  - [x] 미가입 이메일도 초대 가능                                                          
  - [x] 구조화된 응답 반환 `{ success, data | error }`                                     
                                                                                           
  ## 비고                                                                                  
  - 이메일 발송 미구현 (다음 단계)                                                         
  - 초대 수락 플로우 미구현 (다음 단계)