### PR TITLE
feat: 조직 초대 이메일 발송 구현

### DIFF
--- a/apps/assassin/package.json
+++ b/apps/assassin/package.json
@@ -20,6 +20,7 @@
     "@prisma/client": "^7.1.0",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.8",
+    "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-slot": "^1.2.4",
     "@supabase/ssr": "^0.8.0",
@@ -34,9 +35,9 @@
     "react": "19.2.1",
     "react-day-picker": "^9.13.2",
     "react-dom": "19.2.1",
+    "resend": "^6.10.0",
     "tailwind-merge": "^3.4.0",
-    "zod": "^4.1.13",
-    "@radix-ui/react-popover": "^1.1.15"
+    "zod": "^4.1.13"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/apps/assassin/src/features/org/actions.ts
+++ b/apps/assassin/src/features/org/actions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { createServerSupabaseClient } from "@libs/supabase/server";
+import { sendInviteEmail } from "@libs/email/sendInviteEmail";
 import OrgService from "./service";
 import {
   CreateOrgPayload,
@@ -50,7 +51,12 @@ export const inviteMemberAction = async (
   orgId: string,
   input: InviteMemberPayload,
 ): Promise<
-  | { success: true; data: { id: string; email: string; expiresAt: Date } }
+  | {
+      success: true;
+      data: { id: string; email: string; expiresAt: Date };
+      emailSent: boolean;
+      emailError?: string;
+    }
   | { success: false; error: string }
 > => {
   const parsed = inviteMemberSchema.safeParse(input);
@@ -61,9 +67,27 @@ export const inviteMemberAction = async (
   try {
     const userId = await getCurrentUserId();
     const invitation = await OrgService.inviteMember(orgId, userId, parsed.data);
+
+    // 이메일 발송에 필요한 조직명, 초대자 이름 조회
+    const [org, inviterProfile] = await Promise.all([
+      OrgService.getOrgById(orgId),
+      OrgService.getProfileById(userId),
+    ]);
+
+    const emailResult = await sendInviteEmail({
+      to: invitation.email,
+      orgName: org?.name ?? orgId,
+      inviterName: inviterProfile?.name,
+      role: invitation.role,
+      expiresAt: invitation.expiresAt,
+      token: invitation.token,
+    });
+
     return {
       success: true,
       data: { id: invitation.id, email: invitation.email, expiresAt: invitation.expiresAt },
+      emailSent: emailResult.sent,
+      ...(emailResult.error && { emailError: emailResult.error }),
     };
   } catch (error) {
     return {

--- a/apps/assassin/src/features/org/repository.ts
+++ b/apps/assassin/src/features/org/repository.ts
@@ -107,6 +107,10 @@ async function updateInvitationStatus(id: string, status: "ACCEPTED" | "EXPIRED"
   });
 }
 
+async function getProfileById(userId: string) {
+  return await prisma.profile.findUnique({ where: { id: userId } });
+}
+
 // auth.users는 Prisma 스키마 외부(Supabase Auth 스키마)이므로 raw query 사용
 async function findUserIdByEmail(email: string): Promise<string | null> {
   const rows = await prisma.$queryRaw<{ id: string }[]>`
@@ -141,6 +145,7 @@ const OrgRepository = {
   updateInvitationStatus,
   findUserIdByEmail,
   cancelPendingInvitationsByEmail,
+  getProfileById,
 };
 
 export default OrgRepository;

--- a/apps/assassin/src/features/org/repository.ts
+++ b/apps/assassin/src/features/org/repository.ts
@@ -1,4 +1,5 @@
 import { prisma } from "@libs/prisma/client";
+import { Prisma } from "@prisma/client";
 import { CreateOrgPayload, UpdateOrgPayload } from "./schema";
 import crypto from "crypto";
 
@@ -41,8 +42,9 @@ async function deleteOrg(id: string) {
 }
 
 // OrgMember
-async function addMember(orgId: string, userId: string, role: "OWNER" | "MEMBER") {
-  return await prisma.orgMember.create({
+async function addMember(orgId: string, userId: string, role: "OWNER" | "MEMBER", tx?: Prisma.TransactionClient) {
+  const client = tx ?? prisma;
+  return await client.orgMember.create({
     data: { orgId, userId, role },
   });
 }
@@ -74,11 +76,12 @@ async function removeMember(orgId: string, userId: string) {
 }
 
 // OrgInvitation
-async function createInvitation(orgId: string, email: string, role: "MEMBER") {
+async function createInvitation(orgId: string, email: string, role: "MEMBER", tx?: Prisma.TransactionClient) {
   const token = crypto.randomBytes(32).toString("hex");
   const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000); // 7일
+  const client = tx ?? prisma;
 
-  return await prisma.orgInvitation.create({
+  return await client.orgInvitation.create({
     data: {
       orgId,
       email,
@@ -100,8 +103,9 @@ async function getPendingInvitationsByOrg(orgId: string) {
   });
 }
 
-async function updateInvitationStatus(id: string, status: "ACCEPTED" | "EXPIRED" | "CANCELLED") {
-  return await prisma.orgInvitation.update({
+async function updateInvitationStatus(id: string, status: "ACCEPTED" | "EXPIRED" | "CANCELLED", tx?: Prisma.TransactionClient) {
+  const client = tx ?? prisma;
+  return await client.orgInvitation.update({
     where: { id },
     data: { status },
   });
@@ -120,8 +124,9 @@ async function findUserIdByEmail(email: string): Promise<string | null> {
 }
 
 // 동일 (orgId, email)의 PENDING 초대를 모두 취소 — 재초대 시 호출
-async function cancelPendingInvitationsByEmail(orgId: string, email: string): Promise<void> {
-  await prisma.orgInvitation.updateMany({
+async function cancelPendingInvitationsByEmail(orgId: string, email: string, tx?: Prisma.TransactionClient): Promise<void> {
+  const client = tx ?? prisma;
+  await client.orgInvitation.updateMany({
     where: { orgId, email, status: "PENDING" },
     data: { status: "CANCELLED" },
   });

--- a/apps/assassin/src/features/org/service.ts
+++ b/apps/assassin/src/features/org/service.ts
@@ -15,6 +15,10 @@ const createOrg = async (creatorUserId: string, input: CreateOrgPayload) => {
   return org;
 };
 
+const getOrgById = async (orgId: string) => {
+  return await OrgRepository.getOrgById(orgId);
+};
+
 const getOrgBySlug = async (slug: string) => {
   const org = await OrgRepository.getOrgBySlug(slug);
   if (!org) {
@@ -100,8 +104,13 @@ const removeMember = async (orgId: string, targetUserId: string, requesterId: st
   await OrgRepository.removeMember(orgId, targetUserId);
 };
 
+const getProfileById = async (userId: string) => {
+  return await OrgRepository.getProfileById(userId);
+};
+
 const OrgService = {
   createOrg,
+  getOrgById,
   getOrgBySlug,
   getUserOrgs,
   updateOrg,
@@ -111,6 +120,7 @@ const OrgService = {
   acceptInvitation,
   cancelInvitation,
   removeMember,
+  getProfileById,
 };
 
 export default OrgService;

--- a/apps/assassin/src/features/org/service.ts
+++ b/apps/assassin/src/features/org/service.ts
@@ -1,4 +1,6 @@
+import crypto from "crypto";
 import OrgRepository from "./repository";
+import { prisma } from "@libs/prisma/client";
 import { assertOrgMember } from "@libs/auth/assertOrgMember";
 import { CreateOrgPayload, InviteMemberPayload, UpdateOrgPayload } from "./schema";
 
@@ -60,10 +62,20 @@ const inviteMember = async (orgId: string, requesterId: string, input: InviteMem
     }
   }
 
-  // 기존 PENDING 초대 취소 후 재생성 (재초대 정책: PENDING → CANCELLED + 신규 생성)
-  await OrgRepository.cancelPendingInvitationsByEmail(orgId, email);
+  // 기존 PENDING 초대 취소 후 재생성 — 두 작업을 트랜잭션으로 묶어 원자성 보장
+  return await prisma.$transaction(async (tx) => {
+    await tx.orgInvitation.updateMany({
+      where: { orgId, email, status: "PENDING" },
+      data: { status: "CANCELLED" },
+    });
 
-  return await OrgRepository.createInvitation(orgId, email, "MEMBER");
+    const token = crypto.randomBytes(32).toString("hex");
+    const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+
+    return await tx.orgInvitation.create({
+      data: { orgId, email, token, role: "MEMBER", status: "PENDING", expiresAt },
+    });
+  });
 };
 
 const acceptInvitation = async (token: string, userId: string) => {
@@ -82,8 +94,11 @@ const acceptInvitation = async (token: string, userId: string) => {
     throw new Error("만료된 초대입니다.");
   }
 
-  await OrgRepository.addMember(invitation.orgId, userId, "MEMBER");
-  await OrgRepository.updateInvitationStatus(invitation.id, "ACCEPTED");
+  // 멤버 추가와 초대 상태 업데이트를 트랜잭션으로 묶어 원자성 보장
+  await prisma.$transaction(async (tx) => {
+    await tx.orgMember.create({ data: { orgId: invitation.orgId, userId, role: "MEMBER" } });
+    await tx.orgInvitation.update({ where: { id: invitation.id }, data: { status: "ACCEPTED" } });
+  });
 
   return OrgRepository.getOrgById(invitation.orgId);
 };

--- a/apps/assassin/src/features/org/service.ts
+++ b/apps/assassin/src/features/org/service.ts
@@ -1,4 +1,3 @@
-import crypto from "crypto";
 import OrgRepository from "./repository";
 import { prisma } from "@libs/prisma/client";
 import { assertOrgMember } from "@libs/auth/assertOrgMember";
@@ -64,17 +63,8 @@ const inviteMember = async (orgId: string, requesterId: string, input: InviteMem
 
   // 기존 PENDING 초대 취소 후 재생성 — 두 작업을 트랜잭션으로 묶어 원자성 보장
   return await prisma.$transaction(async (tx) => {
-    await tx.orgInvitation.updateMany({
-      where: { orgId, email, status: "PENDING" },
-      data: { status: "CANCELLED" },
-    });
-
-    const token = crypto.randomBytes(32).toString("hex");
-    const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
-
-    return await tx.orgInvitation.create({
-      data: { orgId, email, token, role: "MEMBER", status: "PENDING", expiresAt },
-    });
+    await OrgRepository.cancelPendingInvitationsByEmail(orgId, email, tx);
+    return await OrgRepository.createInvitation(orgId, email, "MEMBER", tx);
   });
 };
 
@@ -96,8 +86,8 @@ const acceptInvitation = async (token: string, userId: string) => {
 
   // 멤버 추가와 초대 상태 업데이트를 트랜잭션으로 묶어 원자성 보장
   await prisma.$transaction(async (tx) => {
-    await tx.orgMember.create({ data: { orgId: invitation.orgId, userId, role: "MEMBER" } });
-    await tx.orgInvitation.update({ where: { id: invitation.id }, data: { status: "ACCEPTED" } });
+    await OrgRepository.addMember(invitation.orgId, userId, "MEMBER", tx);
+    await OrgRepository.updateInvitationStatus(invitation.id, "ACCEPTED", tx);
   });
 
   return OrgRepository.getOrgById(invitation.orgId);

--- a/apps/assassin/src/libs/email/client.ts
+++ b/apps/assassin/src/libs/email/client.ts
@@ -1,0 +1,4 @@
+import { Resend } from "resend";
+
+// RESEND_API_KEY는 서버 전용 환경변수 (클라이언트에 노출 금지)
+export const resend = new Resend(process.env.RESEND_API_KEY!);

--- a/apps/assassin/src/libs/email/sendInviteEmail.ts
+++ b/apps/assassin/src/libs/email/sendInviteEmail.ts
@@ -1,0 +1,61 @@
+import { resend } from "./client";
+
+interface SendInviteEmailParams {
+  to: string;
+  orgName: string;
+  inviterName?: string;
+  role: string;
+  expiresAt: Date;
+  token: string;
+}
+
+interface SendInviteEmailResult {
+  sent: boolean;
+  error?: string;
+}
+
+export async function sendInviteEmail({
+  to,
+  orgName,
+  inviterName,
+  role,
+  expiresAt,
+  token,
+}: SendInviteEmailParams): Promise<SendInviteEmailResult> {
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL;
+  const acceptUrl = `${appUrl}/invite/accept?token=${token}`;
+
+  const expiresAtFormatted = expiresAt.toLocaleDateString("ko-KR", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+
+  const inviterLine = inviterName ? `${inviterName}님이 ` : "";
+
+  try {
+    await resend.emails.send({
+      from: process.env.RESEND_FROM_EMAIL ?? "noreply@example.com",
+      to,
+      subject: `[${orgName}] 조직 초대장`,
+      html: `
+        <p>${inviterLine}<strong>${orgName}</strong>에 초대했습니다.</p>
+        <p>역할: <strong>${role}</strong></p>
+        <p>초대 만료일: ${expiresAtFormatted}</p>
+        <br />
+        <a href="${acceptUrl}" style="display:inline-block;padding:10px 20px;background:#000;color:#fff;text-decoration:none;border-radius:4px;">
+          초대 수락하기
+        </a>
+        <br /><br />
+        <p style="color:#666;font-size:12px;">링크가 작동하지 않으면 아래 주소를 브라우저에 붙여넣으세요:<br />${acceptUrl}</p>
+      `,
+    });
+
+    return { sent: true };
+  } catch (error) {
+    return {
+      sent: false,
+      error: error instanceof Error ? error.message : "이메일 발송 실패",
+    };
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
       react-dom:
         specifier: 19.2.1
         version: 19.2.1(react@19.2.1)
+      resend:
+        specifier: ^6.10.0
+        version: 6.10.0
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
@@ -2119,6 +2122,9 @@ packages:
     resolution: {integrity: sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==}
     engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
@@ -3125,6 +3131,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
@@ -3924,6 +3933,9 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
+  postal-mime@2.7.4:
+    resolution: {integrity: sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==}
+
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -4109,6 +4121,15 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  resend@6.10.0:
+    resolution: {integrity: sha512-i7CwZpYj4Oho1RxsTpLcCUkO08+HiL4NXrm6jLJ2WzJ89UGI8eROSieLONJA3hnUrf1OYnCyfq5F6POnHUMv1Q==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@react-email/render': '*'
+    peerDependenciesMeta:
+      '@react-email/render':
+        optional: true
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -4270,6 +4291,9 @@ packages:
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
@@ -4340,6 +4364,9 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  svix@1.88.0:
+    resolution: {integrity: sha512-vm/JrrUd3bVyBE+3L33TIyVSs8gS5fYx7lrISvKlDJXTYX1ACH4REX8P1tHxsSKoZi/rvifM1t0XRc5Vc45THw==}
 
   synckit@0.11.11:
     resolution: {integrity: sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==}
@@ -4540,6 +4567,10 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    hasBin: true
 
   valibot@1.2.0:
     resolution: {integrity: sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==}
@@ -6814,6 +6845,8 @@ snapshots:
 
   '@sapphire/snowflake@3.5.3': {}
 
+  '@stablelib/base64@1.0.1': {}
+
   '@standard-schema/spec@1.0.0': {}
 
   '@supabase/auth-js@2.86.0':
@@ -8044,6 +8077,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-sha256@1.3.0: {}
+
   fast-uri@3.1.0: {}
 
   fastq@1.19.1:
@@ -8795,6 +8830,8 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
+  postal-mime@2.7.4: {}
+
   postcss@8.4.31:
     dependencies:
       nanoid: 3.3.11
@@ -9031,6 +9068,11 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  resend@6.10.0:
+    dependencies:
+      postal-mime: 2.7.4
+      svix: 1.88.0
+
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -9220,6 +9262,11 @@ snapshots:
 
   stable-hash@0.0.5: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   std-env@3.9.0: {}
 
   stop-iteration-iterator@1.1.0:
@@ -9305,6 +9352,11 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  svix@1.88.0:
+    dependencies:
+      standardwebhooks: 1.0.0
+      uuid: 10.0.0
 
   synckit@0.11.11:
     dependencies:
@@ -9520,6 +9572,8 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.2.1):
     dependencies:
       react: 19.2.1
+
+  uuid@10.0.0: {}
 
   valibot@1.2.0(typescript@5.9.3):
     optionalDependencies:


### PR DESCRIPTION
  ## 변경 내용

  ### 이메일 발송 레이어 추가
  - Resend SDK 연동 (`libs/email/client.ts`)
  - 초대 이메일 발송 함수 (`libs/email/sendInviteEmail.ts`)
    - 조직명, 초대자 이름, 역할, 만료일, 수락 링크 포함

  ### 초대 생성 액션 연결
  - 초대 DB 생성 후 이메일 발송
  - 이메일 실패 시 초대 레코드 유지 + `emailSent: false`, `emailError` 반환
  - 호출자가 재시도 UI 여부 결정 가능

  ### 환경변수
  - `RESEND_API_KEY` — GitHub Secret으로 관리
  - `RESEND_FROM_EMAIL` — 인증된 발신 도메인
  - `NEXT_PUBLIC_APP_URL` — 초대 수락 링크 base URL

  ## 완료 조건
  - [x] 초대 생성 후 이메일 자동 발송
  - [x] 이메일 실패 시 명시적 에러 반환 (silent ignore 없음)
  - [x] 수락 URL 형식: `{APP_URL}/invite/accept?token=...`
  - [x] 비민감 환경변수 config/.env.local에 문서화

  ## 비고
  - 초대 수락 플로우 미구현 (다음 단계)
  - UI 미구현 (다음 단계)