### PR TITLE
[#164] Codex 세션 이어받기 유지

### DIFF
--- a/apps/assassin/package.json
+++ b/apps/assassin/package.json
@@ -20,6 +20,7 @@
     "@prisma/client": "^7.1.0",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.8",
+    "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-slot": "^1.2.4",
     "@supabase/ssr": "^0.8.0",
@@ -34,9 +35,9 @@
     "react": "19.2.1",
     "react-day-picker": "^9.13.2",
     "react-dom": "19.2.1",
+    "resend": "^6.10.0",
     "tailwind-merge": "^3.4.0",
-    "zod": "^4.1.13",
-    "@radix-ui/react-popover": "^1.1.15"
+    "zod": "^4.1.13"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/apps/assassin/src/app/org/[orgSlug]/settings/members/page.tsx
+++ b/apps/assassin/src/app/org/[orgSlug]/settings/members/page.tsx
@@ -1,17 +1,44 @@
-import { AppNav } from "@/components/navigation/AppNav";
+import { redirect } from "next/navigation";
+import { createServerSupabaseClient } from "@libs/supabase/server";
+import {
+  getOrgBySlugAction,
+  getOrgMembersAction,
+  getPendingInvitationsAction,
+} from "@features/org/actions";
+import type { OrgMember } from "@features/org/schema";
+import { MembersPageClient } from "@features/org/components/MembersPageClient";
 
-export default function SettingsMembersPage() {
+interface Props {
+  params: Promise<{ orgSlug: string }>;
+}
+
+export default async function SettingsMembersPage({ params }: Props) {
+  const { orgSlug } = await params;
+
+  const supabase = await createServerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/");
+
+  const org = await getOrgBySlugAction(orgSlug).catch(() => null);
+  if (!org) redirect(`/org/${orgSlug}`);
+
+  const [members, pendingInvitations] = await Promise.all([
+    getOrgMembersAction(org.id).catch(() => []),
+    getPendingInvitationsAction(org.id).catch(() => []),
+  ]);
+
+  // OWNER만 접근 가능
+  const currentMember = members.find((m: OrgMember) => m.userId === user.id);
+  if (currentMember?.role !== "OWNER") redirect(`/org/${orgSlug}`);
+
   return (
-    <div className="h-screen bg-slate-50 dark:bg-slate-950 overflow-hidden">
-      <div className="w-full px-3 sm:px-6 lg:px-8 py-4 sm:py-6 h-full">
-        <div className="bg-white dark:bg-slate-900 rounded-lg p-4 sm:p-6 shadow-sm border border-slate-200 dark:border-slate-800 h-full flex flex-col min-h-0 overflow-y-auto">
-          <AppNav />
-          <div className="max-w-lg flex flex-col gap-4 pt-4">
-            <h1 className="text-xl font-semibold text-slate-900 dark:text-slate-50">멤버 관리</h1>
-            <p className="text-sm text-muted-foreground">멤버 관리 기능은 준비 중입니다.</p>
-          </div>
-        </div>
-      </div>
-    </div>
+    <MembersPageClient
+      org={org}
+      members={members}
+      pendingInvitations={pendingInvitations}
+      currentUserId={user.id}
+    />
   );
 }

--- a/apps/assassin/src/features/org/actions.ts
+++ b/apps/assassin/src/features/org/actions.ts
@@ -2,6 +2,7 @@
 
 import { createServerSupabaseClient } from "@libs/supabase/server";
 import OrgService from "./service";
+import { sendInviteEmail } from "@libs/email/sendInviteEmail";
 import {
   CreateOrgPayload,
   InviteMemberPayload,
@@ -50,7 +51,7 @@ export const inviteMemberAction = async (
   orgId: string,
   input: InviteMemberPayload,
 ): Promise<
-  | { success: true; data: { id: string; email: string; expiresAt: Date } }
+  | { success: true; data: { id: string; email: string; expiresAt: Date }; emailSent: boolean; emailError?: string }
   | { success: false; error: string }
 > => {
   const parsed = inviteMemberSchema.safeParse(input);
@@ -61,9 +62,37 @@ export const inviteMemberAction = async (
   try {
     const userId = await getCurrentUserId();
     const invitation = await OrgService.inviteMember(orgId, userId, parsed.data);
+
+    let emailSent = false;
+    let emailError: string | undefined;
+
+    try {
+      const [org, inviterProfile] = await Promise.all([
+        OrgService.getOrgById(orgId),
+        OrgService.getProfileById(userId),
+      ]);
+
+      const emailResult = await sendInviteEmail({
+        to: invitation.email,
+        orgName: org?.name ?? orgId,
+        inviterName: inviterProfile?.name,
+        role: invitation.role,
+        expiresAt: invitation.expiresAt,
+        token: invitation.token,
+      });
+
+      emailSent = emailResult.sent;
+      emailError = emailResult.error;
+    } catch (error) {
+      emailSent = false;
+      emailError = error instanceof Error ? error.message : "이메일 발송 실패";
+    }
+
     return {
       success: true,
       data: { id: invitation.id, email: invitation.email, expiresAt: invitation.expiresAt },
+      emailSent,
+      ...(emailError && { emailError }),
     };
   } catch (error) {
     return {
@@ -71,6 +100,11 @@ export const inviteMemberAction = async (
       error: error instanceof Error ? error.message : "초대 생성에 실패했습니다.",
     };
   }
+};
+
+export const getPendingInvitationsAction = async (orgId: string) => {
+  const userId = await getCurrentUserId();
+  return await OrgService.getPendingInvitations(orgId, userId);
 };
 
 export const acceptInvitationAction = async (token: string) => {

--- a/apps/assassin/src/features/org/components/MembersPageClient.tsx
+++ b/apps/assassin/src/features/org/components/MembersPageClient.tsx
@@ -1,0 +1,232 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { AppNav } from "@/components/navigation/AppNav";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
+import { inviteMemberAction, cancelInvitationAction, removeMemberAction } from "../actions";
+
+type MemberWithProfile = {
+  id: string;
+  userId: string;
+  role: string;
+  profile: { name: string; realName: string } | null;
+};
+
+type PendingInvitation = {
+  id: string;
+  email: string;
+  expiresAt: Date;
+};
+
+type Org = {
+  id: string;
+  name: string;
+  slug: string;
+};
+
+interface Props {
+  org: Org;
+  members: MemberWithProfile[];
+  pendingInvitations: PendingInvitation[];
+  currentUserId: string;
+}
+
+export function MembersPageClient({ org, members, pendingInvitations, currentUserId }: Props) {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [inviteError, setInviteError] = useState<string | null>(null);
+  const [inviteWarning, setInviteWarning] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const handleInvite = (e: React.FormEvent) => {
+    e.preventDefault();
+    setInviteError(null);
+    setInviteWarning(null);
+
+    startTransition(async () => {
+      const result = await inviteMemberAction(org.id, { email, role: "MEMBER" });
+      if (!result.success) {
+        setInviteError(result.error);
+        return;
+      }
+      setEmail("");
+      if (!result.emailSent) {
+        setInviteWarning(
+          `초대가 생성되었지만 이메일 발송에 실패했습니다. (${result.emailError ?? "알 수 없는 오류"})`,
+        );
+      }
+      router.refresh();
+    });
+  };
+
+  const handleResendInvitation = (targetEmail: string) => {
+    setInviteError(null);
+    setInviteWarning(null);
+
+    startTransition(async () => {
+      const result = await inviteMemberAction(org.id, { email: targetEmail, role: "MEMBER" });
+      if (!result.success) {
+        setInviteError(result.error);
+        return;
+      }
+
+      if (!result.emailSent) {
+        setInviteWarning(
+          `재발송 초대가 생성되었지만 이메일 발송에 실패했습니다. (${result.emailError ?? "알 수 없는 오류"})`,
+        );
+      }
+      router.refresh();
+    });
+  };
+
+  const handleCancelInvitation = (invitationId: string) => {
+    startTransition(async () => {
+      await cancelInvitationAction(invitationId, org.id);
+      router.refresh();
+    });
+  };
+
+  const handleRemoveMember = (targetUserId: string) => {
+    startTransition(async () => {
+      await removeMemberAction(org.id, targetUserId);
+      router.refresh();
+    });
+  };
+
+  return (
+    <div className="h-screen bg-slate-50 dark:bg-slate-950 overflow-hidden">
+      <div className="w-full px-3 sm:px-6 lg:px-8 py-4 sm:py-6 h-full">
+        <div className="bg-white dark:bg-slate-900 rounded-lg p-4 sm:p-6 shadow-sm border border-slate-200 dark:border-slate-800 h-full flex flex-col min-h-0 overflow-y-auto">
+          <AppNav />
+
+          <div className="max-w-lg flex flex-col gap-8 pt-4">
+            <h1 className="text-xl font-semibold text-slate-900 dark:text-slate-50">멤버 관리</h1>
+
+            {/* 초대 폼 */}
+            <section className="flex flex-col gap-4">
+              <h2 className="text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wider">
+                멤버 초대
+              </h2>
+              <form onSubmit={handleInvite} className="flex flex-col gap-1.5">
+                <Label htmlFor="invite-email" className="text-slate-700 dark:text-slate-300">
+                  이메일
+                </Label>
+                <div className="flex gap-2">
+                  <Input
+                    id="invite-email"
+                    type="email"
+                    placeholder="name@example.com"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    required
+                    disabled={isPending}
+                    className="bg-white dark:bg-slate-900 border-slate-200 dark:border-slate-700"
+                  />
+                  <Button
+                    type="submit"
+                    disabled={isPending || !email}
+                    className="bg-blue-500 hover:bg-blue-600 text-white shrink-0"
+                  >
+                    {isPending ? "전송 중..." : "초대"}
+                  </Button>
+                </div>
+                {inviteError && <p className="text-sm text-red-500">{inviteError}</p>}
+                {inviteWarning && <p className="text-sm text-yellow-600">{inviteWarning}</p>}
+              </form>
+            </section>
+
+            <Separator />
+
+            {/* 대기 중인 초대 */}
+            {pendingInvitations.length > 0 && (
+              <>
+                <section className="flex flex-col gap-4">
+                  <h2 className="text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wider">
+                    초대 대기 중 ({pendingInvitations.length})
+                  </h2>
+                  <ul className="flex flex-col gap-2">
+                    {pendingInvitations.map((inv) => (
+                      <li
+                        key={inv.id}
+                        className="flex items-center justify-between rounded-lg border border-slate-200 dark:border-slate-800 px-4 py-3"
+                      >
+                        <div>
+                          <p className="text-sm font-medium text-slate-900 dark:text-slate-50">
+                            {inv.email}
+                          </p>
+                          <p className="text-xs text-slate-500 dark:text-slate-400">
+                            만료: {new Date(inv.expiresAt).toLocaleDateString("ko-KR")}
+                          </p>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            disabled={isPending}
+                            onClick={() => handleResendInvitation(inv.email)}
+                            className="text-slate-700 border-slate-300 hover:bg-slate-100 dark:text-slate-200 dark:border-slate-700 dark:hover:bg-slate-800"
+                          >
+                            이메일 재발송
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            disabled={isPending}
+                            onClick={() => handleCancelInvitation(inv.id)}
+                            className="text-red-500 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-950"
+                          >
+                            취소
+                          </Button>
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+                <Separator />
+              </>
+            )}
+
+            {/* 멤버 목록 */}
+            <section className="flex flex-col gap-4">
+              <h2 className="text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wider">
+                멤버 ({members.length})
+              </h2>
+              <ul className="flex flex-col gap-2">
+                {members.map((member) => (
+                  <li
+                    key={member.id}
+                    className="flex items-center justify-between rounded-lg border border-slate-200 dark:border-slate-800 px-4 py-3"
+                  >
+                    <div>
+                      <p className="text-sm font-medium text-slate-900 dark:text-slate-50">
+                        {member.profile?.name ?? "알 수 없음"}
+                      </p>
+                      <p className="text-xs text-slate-500 dark:text-slate-400">
+                        {member.role === "OWNER" ? "오너" : "멤버"}
+                      </p>
+                    </div>
+                    {member.role !== "OWNER" && member.userId !== currentUserId && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        disabled={isPending}
+                        onClick={() => handleRemoveMember(member.userId)}
+                        className="text-red-500 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-950"
+                      >
+                        제거
+                      </Button>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </section>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/assassin/src/features/org/components/OrgSettingsPageClient.tsx
+++ b/apps/assassin/src/features/org/components/OrgSettingsPageClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { FormEvent, useState } from "react";
+import Link from "next/link";
 import { AppNav } from "@/components/navigation/AppNav";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -74,6 +75,25 @@ export function OrgSettingsPageClient({ orgSlug }: OrgSettingsPageClientProps) {
                   </Button>
                 </div>
               </form>
+            </section>
+
+            <Separator />
+
+            <section className="flex flex-col gap-4">
+              <h2 className="text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wider">
+                멤버
+              </h2>
+              <div className="rounded-lg border border-slate-200 dark:border-slate-800 p-4 flex items-center justify-between gap-4">
+                <div>
+                  <p className="text-sm font-medium text-slate-900 dark:text-slate-50">멤버 관리</p>
+                  <p className="text-sm text-muted-foreground mt-0.5">
+                    멤버 초대, 제거 및 초대 현황을 관리합니다.
+                  </p>
+                </div>
+                <Button variant="outline" size="sm" asChild>
+                  <Link href={`/org/${org.slug}/settings/members`}>관리</Link>
+                </Button>
+              </div>
             </section>
 
             <Separator />

--- a/apps/assassin/src/features/org/repository.ts
+++ b/apps/assassin/src/features/org/repository.ts
@@ -107,6 +107,10 @@ async function updateInvitationStatus(id: string, status: "ACCEPTED" | "EXPIRED"
   });
 }
 
+async function getProfileById(userId: string) {
+  return await prisma.profile.findUnique({ where: { id: userId } });
+}
+
 // auth.users는 Prisma 스키마 외부(Supabase Auth 스키마)이므로 raw query 사용
 async function findUserIdByEmail(email: string): Promise<string | null> {
   const rows = await prisma.$queryRaw<{ id: string }[]>`
@@ -141,6 +145,7 @@ const OrgRepository = {
   updateInvitationStatus,
   findUserIdByEmail,
   cancelPendingInvitationsByEmail,
+  getProfileById,
 };
 
 export default OrgRepository;

--- a/apps/assassin/src/features/org/service.ts
+++ b/apps/assassin/src/features/org/service.ts
@@ -42,6 +42,19 @@ const getOrgMembers = async (orgId: string, requesterId: string) => {
   return await OrgRepository.getOrgMembers(orgId);
 };
 
+const getOrgById = async (orgId: string) => {
+  return await OrgRepository.getOrgById(orgId);
+};
+
+const getProfileById = async (userId: string) => {
+  return await OrgRepository.getProfileById(userId);
+};
+
+const getPendingInvitations = async (orgId: string, requesterId: string) => {
+  await assertOrgMember(requesterId, orgId);
+  return await OrgRepository.getPendingInvitationsByOrg(orgId);
+};
+
 const inviteMember = async (orgId: string, requesterId: string, input: InviteMemberPayload) => {
   await assertOrgMember(requesterId, orgId, "OWNER");
 
@@ -102,11 +115,14 @@ const removeMember = async (orgId: string, targetUserId: string, requesterId: st
 
 const OrgService = {
   createOrg,
+  getOrgById,
   getOrgBySlug,
   getUserOrgs,
   updateOrg,
   deleteOrg,
   getOrgMembers,
+  getProfileById,
+  getPendingInvitations,
   inviteMember,
   acceptInvitation,
   cancelInvitation,

--- a/apps/assassin/src/libs/email/client.ts
+++ b/apps/assassin/src/libs/email/client.ts
@@ -1,0 +1,4 @@
+import { Resend } from "resend";
+
+// RESEND_API_KEY는 서버 전용 환경변수 (클라이언트에 노출 금지)
+export const resend = new Resend(process.env.RESEND_API_KEY!);

--- a/apps/assassin/src/libs/email/sendInviteEmail.ts
+++ b/apps/assassin/src/libs/email/sendInviteEmail.ts
@@ -1,0 +1,61 @@
+import { resend } from "./client";
+
+interface SendInviteEmailParams {
+  to: string;
+  orgName: string;
+  inviterName?: string;
+  role: string;
+  expiresAt: Date;
+  token: string;
+}
+
+interface SendInviteEmailResult {
+  sent: boolean;
+  error?: string;
+}
+
+export async function sendInviteEmail({
+  to,
+  orgName,
+  inviterName,
+  role,
+  expiresAt,
+  token,
+}: SendInviteEmailParams): Promise<SendInviteEmailResult> {
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL;
+  const acceptUrl = `${appUrl}/invite/accept?token=${token}`;
+
+  const expiresAtFormatted = expiresAt.toLocaleDateString("ko-KR", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+
+  const inviterLine = inviterName ? `${inviterName}님이 ` : "";
+
+  try {
+    await resend.emails.send({
+      from: process.env.RESEND_FROM_EMAIL ?? "noreply@example.com",
+      to,
+      subject: `[${orgName}] 조직 초대장`,
+      html: `
+        <p>${inviterLine}<strong>${orgName}</strong>에 초대했습니다.</p>
+        <p>역할: <strong>${role}</strong></p>
+        <p>초대 만료일: ${expiresAtFormatted}</p>
+        <br />
+        <a href="${acceptUrl}" style="display:inline-block;padding:10px 20px;background:#000;color:#fff;text-decoration:none;border-radius:4px;">
+          초대 수락하기
+        </a>
+        <br /><br />
+        <p style="color:#666;font-size:12px;">링크가 작동하지 않으면 아래 주소를 브라우저에 붙여넣으세요:<br />${acceptUrl}</p>
+      `,
+    });
+
+    return { sent: true };
+  } catch (error) {
+    return {
+      sent: false,
+      error: error instanceof Error ? error.message : "이메일 발송 실패",
+    };
+  }
+}

--- a/apps/ymm/src/codex/runner.ts
+++ b/apps/ymm/src/codex/runner.ts
@@ -36,6 +36,8 @@ const APPROVAL_RE = /\[y\/n\]|\[Y\/n\]|\[y\/N\]|\(y\/n\)|\(Y\/n\)/i
 type SendFn = (content: string) => Promise<unknown>
 
 type RunOptions = {
+  sessionId?: string
+  onSessionId?: (sessionId: string) => void
   onDone?: () => void
   logChannel?: { send: SendFn }
   resultChannel?: { send: SendFn }
@@ -49,46 +51,85 @@ export function runCodexCode(
   message: Message,
   processingMsg: Message,
   tempFiles: string[],
-  { onDone, logChannel, resultChannel, commandChannel, onApprovalRequest }: RunOptions = {},
+  { sessionId, onSessionId, onDone, logChannel, resultChannel, commandChannel, onApprovalRequest }: RunOptions = {},
 ) {
   const start = Date.now()
   const discordLogger = createDiscordLogger(
     logChannel ?? (message.channel as { send: SendFn }),
   )
-  const fullPrompt =
-    WORKFLOW_RULES + buildSharedAgentContextPrompt({ projectRoot: PROJECT_ROOT }) + prompt
+  const sharedContext = buildSharedAgentContextPrompt({ projectRoot: PROJECT_ROOT })
+  const fullPrompt = WORKFLOW_RULES + (sessionId ? '' : sharedContext) + prompt
+
+  const baseArgs = ['--json', '--dangerously-bypass-approvals-and-sandbox']
+  const args = sessionId
+    ? ['exec', 'resume', ...baseArgs, sessionId, fullPrompt]
+    : ['exec', ...baseArgs, fullPrompt]
 
   // dangerously-bypass-approvals-and-sandbox: 샌드박스 없이 실행
   // 이 봇은 전용 레포 안에서만 동작하므로 샌드박스 우회가 적합함
   // (--full-auto의 workspace-write 샌드박스는 .git/ 쓰기를 막아 git pull이 불가)
-  const child = spawn(
-    CODEX_BIN,
-    ['exec', '--dangerously-bypass-approvals-and-sandbox', fullPrompt],
-    {
-      cwd: PROJECT_ROOT,
-      env: { ...process.env },
-      stdio: ['pipe', 'pipe', 'pipe'],
-    },
-  )
+  const child = spawn(CODEX_BIN, args, {
+    cwd: PROJECT_ROOT,
+    env: { ...process.env },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  })
   // stdin을 즉시 닫아 codex가 "Reading additional input from stdin..." 상태에서 블로킹되지 않도록 함
   child.stdin.end()
 
   let output = ''
+  const addOutput = (line: string) => {
+    output += line + '\n'
+  }
 
   const rl = readline.createInterface({ input: child.stdout, crlfDelay: Infinity })
   rl.on('line', (line) => {
-    output += line + '\n'
-    discordLogger.log(`🧠 [codex] ${truncate(line, 500)}`)
+    let event: { type?: string; thread_id?: string; item?: { text?: string } }
+    try {
+      event = JSON.parse(line)
+    } catch {
+      addOutput(line)
+      if (APPROVAL_RE.test(line)) {
+        handleApproval(line)
+      } else {
+        discordLogger.log(`🧠 [codex] ${truncate(line, 500)}`)
+      }
+      return
+    }
 
-    if (APPROVAL_RE.test(line)) {
-      console.log(`${ts()} ${c.yellow}[codex 승인 요청]${c.reset} ${line}`)
+    if (event.type === 'thread.started') {
+      if (event.thread_id) {
+        onSessionId?.(event.thread_id)
+      }
+      return
+    }
+
+    if (event.type === 'item.completed' && event.item?.text) {
+      const text = String(event.item.text).trim()
+      if (text) addOutput(text)
+      return
+    }
+
+    if (event.type === 'turn.completed') {
+      return
+    }
+
+    const lineText = line.includes(':') ? line.slice(line.indexOf(':') + 1).trim() : ''
+    addOutput(lineText || line)
+    if (lineText && APPROVAL_RE.test(lineText)) {
+      handleApproval(lineText)
+      return
+    }
+    discordLogger.log(`🧠 [codex] ${truncate(lineText || line, 500)}`)
+
+    function handleApproval(text: string) {
+      console.log(`${ts()} ${c.yellow}[codex 승인 요청]${c.reset} ${text}`)
       const target = commandChannel ?? (message.channel as { send: SendFn })
       target
-        .send(`❓ **Codex 승인 요청**\n\`\`\`\n${truncate(line, 500)}\n\`\`\`\n\`y\` 또는 \`n\`으로 답해주세요. (60초 내 무응답 시 자동으로 \`n\`)`)
+        .send(`❓ **Codex 승인 요청**\n\`\`\`\n${truncate(text, 500)}\n\`\`\`\n\`y\` 또는 \`n\`으로 답해주세요. (60초 내 무응답 시 자동으로 \`n\`)`)
         .catch(() => {})
 
       if (onApprovalRequest) {
-        onApprovalRequest(line)
+        onApprovalRequest(text)
           .then((response) => {
             child.stdin.write(response.trim() + '\n')
             discordLogger.log(`✅ [승인 응답] ${response.trim()}`)

--- a/apps/ymm/src/discord/bot.ts
+++ b/apps/ymm/src/discord/bot.ts
@@ -84,6 +84,7 @@ client.on('messageCreate', async (message: Message) => {
       return
     }
     const nextAgent = text.endsWith('codex') ? 'codex' : 'claude'
+    clearSession(message.channelId)
     setAgent(message.channelId, nextAgent)
     await message.reply(`✅ 현재 채널 에이전트가 **${nextAgent}** 로 변경되었습니다.`)
     return
@@ -218,6 +219,8 @@ client.on('messageCreate', async (message: Message) => {
           commandChannel: getTextChannel(DISCORD_COMMAND_ID),
         })
       : runCodexCode(prompt, message, processingMsg, tempFiles, {
+          sessionId,
+          onSessionId: (id) => setSession(message.channelId, id),
           onDone: () => clearProcess(message.channelId),
           logChannel: getTextChannel(DISCORD_LOG_ID),
           resultChannel: getTextChannel(DISCORD_RESULT_ID),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
       react-dom:
         specifier: 19.2.1
         version: 19.2.1(react@19.2.1)
+      resend:
+        specifier: ^6.10.0
+        version: 6.10.0
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
@@ -2119,6 +2122,9 @@ packages:
     resolution: {integrity: sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==}
     engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
@@ -3125,6 +3131,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
@@ -3924,6 +3933,9 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
+  postal-mime@2.7.4:
+    resolution: {integrity: sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==}
+
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -4109,6 +4121,15 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  resend@6.10.0:
+    resolution: {integrity: sha512-i7CwZpYj4Oho1RxsTpLcCUkO08+HiL4NXrm6jLJ2WzJ89UGI8eROSieLONJA3hnUrf1OYnCyfq5F6POnHUMv1Q==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@react-email/render': '*'
+    peerDependenciesMeta:
+      '@react-email/render':
+        optional: true
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -4270,6 +4291,9 @@ packages:
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
@@ -4340,6 +4364,9 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  svix@1.88.0:
+    resolution: {integrity: sha512-vm/JrrUd3bVyBE+3L33TIyVSs8gS5fYx7lrISvKlDJXTYX1ACH4REX8P1tHxsSKoZi/rvifM1t0XRc5Vc45THw==}
 
   synckit@0.11.11:
     resolution: {integrity: sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==}
@@ -4540,6 +4567,10 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    hasBin: true
 
   valibot@1.2.0:
     resolution: {integrity: sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==}
@@ -6814,6 +6845,8 @@ snapshots:
 
   '@sapphire/snowflake@3.5.3': {}
 
+  '@stablelib/base64@1.0.1': {}
+
   '@standard-schema/spec@1.0.0': {}
 
   '@supabase/auth-js@2.86.0':
@@ -8044,6 +8077,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-sha256@1.3.0: {}
+
   fast-uri@3.1.0: {}
 
   fastq@1.19.1:
@@ -8795,6 +8830,8 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
+  postal-mime@2.7.4: {}
+
   postcss@8.4.31:
     dependencies:
       nanoid: 3.3.11
@@ -9031,6 +9068,11 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  resend@6.10.0:
+    dependencies:
+      postal-mime: 2.7.4
+      svix: 1.88.0
+
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -9220,6 +9262,11 @@ snapshots:
 
   stable-hash@0.0.5: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   std-env@3.9.0: {}
 
   stop-iteration-iterator@1.1.0:
@@ -9305,6 +9352,11 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  svix@1.88.0:
+    dependencies:
+      standardwebhooks: 1.0.0
+      uuid: 10.0.0
 
   synckit@0.11.11:
     dependencies:
@@ -9520,6 +9572,8 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.2.1):
     dependencies:
       react: 19.2.1
+
+  uuid@10.0.0: {}
 
   valibot@1.2.0(typescript@5.9.3):
     optionalDependencies:


### PR DESCRIPTION
## 변경사항
- Codex 실행에 `sessionId` 재개 경로를 연결해 같은 채널에서 동일 세션을 재사용
- Codex runner가 `codex exec`의 `thread.started` 이벤트에서 세션 ID를 읽어 저장
- 재개 세션에서 기본 컨텍스트 재삽입을 생략해 불필요한 `CLAUDE.md`/스킬 목록 반복 주입 감소
- 에이전트 전환 시 채널 세션을 초기화해 잘못된 세션 재사용 방지

## 완료 조건
- [x] Codex가 `done` 또는 `!stop` 전까지 채널 세션을 유지한다.
- [x] `done` 또는 `!stop` 이전 요청에서 기본 컨텍스트가 매번 재삽입되지 않는다.
- [x] `npm test` 및 `npm run build` 통과
