### PR TITLE
feat: 조직 초대 이메일 발송 UI 및 수락 플로우 구현

### DIFF
--- a/apps/assassin/prisma/schema.prisma
+++ b/apps/assassin/prisma/schema.prisma
@@ -197,6 +197,8 @@ model OrgInvitation {
 enum OrgRole {
   OWNER
   MEMBER
+
+  @@map("org_role")
 }
 
 enum InvitationStatus {
@@ -204,4 +206,6 @@ enum InvitationStatus {
   ACCEPTED
   EXPIRED
   CANCELLED
+
+  @@map("invitation_status")
 }

--- a/apps/assassin/prisma/schema.prisma
+++ b/apps/assassin/prisma/schema.prisma
@@ -185,10 +185,11 @@ model OrgInvitation {
   token     String           @unique
   role      OrgRole          @default(MEMBER)
   status    InvitationStatus @default(PENDING)
-  expiresAt DateTime         @db.Timestamptz(6)
-  createdAt DateTime         @default(now()) @db.Timestamptz(6)
-  updatedAt DateTime         @default(now()) @db.Timestamptz(6)
-  org       Org              @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  expiresAt   DateTime         @db.Timestamptz(6)
+  emailSentAt DateTime?        @db.Timestamptz(6)
+  createdAt   DateTime         @default(now()) @db.Timestamptz(6)
+  updatedAt   DateTime         @default(now()) @db.Timestamptz(6)
+  org         Org              @relation(fields: [orgId], references: [id], onDelete: Cascade)
 
   @@map("org_invitation")
 }

--- a/apps/assassin/src/app/invite/accept/page.tsx
+++ b/apps/assassin/src/app/invite/accept/page.tsx
@@ -73,7 +73,7 @@ export default async function InviteAcceptPage({
 
   // 미인증 → 로그인 후 이 페이지로 돌아오도록 next 파라미터 전달
   if (!user || !user.email) {
-    redirect(`/login?next=/invite/accept?token=${token}`);
+    redirect(`/login?next=${encodeURIComponent(`/invite/accept?token=${token}`)}`);
   }
 
   try {

--- a/apps/assassin/src/app/invite/accept/page.tsx
+++ b/apps/assassin/src/app/invite/accept/page.tsx
@@ -71,16 +71,18 @@ export default async function InviteAcceptPage({
     data: { user },
   } = await supabase.auth.getUser();
 
-  // 미인증 → 로그인 후 이 페이지로 돌아오도록 next 파라미터 전달
+  // 미인증 → 회원가입(신규) 또는 로그인(기존) 후 이 페이지로 돌아오도록 next 파라미터 전달
   if (!user || !user.email) {
-    redirect(`/login?next=${encodeURIComponent(`/invite/accept?token=${token}`)}`);
+    redirect(`/signup?next=${encodeURIComponent(`/invite/accept?token=${token}`)}`);
   }
 
+  let orgSlug: string;
   try {
     const org = await OrgService.acceptInvitation(token, user.id, user.email);
-    redirect(`/org/${org.slug}`);
+    orgSlug = org.slug;
   } catch (error) {
     const code = error instanceof Error ? error.message : "ERROR";
     return <InviteErrorCard code={code} />;
   }
+  redirect(`/org/${orgSlug}`);
 }

--- a/apps/assassin/src/app/invite/accept/page.tsx
+++ b/apps/assassin/src/app/invite/accept/page.tsx
@@ -1,0 +1,86 @@
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { createServerSupabaseClient } from "@libs/supabase/server";
+import OrgService from "@features/org/service";
+
+// 에러 코드 → 유저에게 보여줄 메시지 매핑
+function getErrorContent(code: string): { title: string; description: string } {
+  switch (code) {
+    case "INVALID_TOKEN":
+      return {
+        title: "유효하지 않은 초대",
+        description: "초대 링크가 올바르지 않습니다. 이메일에서 링크를 다시 확인해주세요.",
+      };
+    case "EXPIRED":
+      return {
+        title: "만료된 초대",
+        description: "초대 링크가 만료되었습니다. 조직 관리자에게 재초대를 요청해주세요.",
+      };
+    case "REVOKED":
+      return {
+        title: "취소된 초대",
+        description: "초대가 취소되었습니다. 조직 관리자에게 문의해주세요.",
+      };
+    case "ALREADY_ACCEPTED":
+      return {
+        title: "이미 수락된 초대",
+        description: "이미 조직의 멤버입니다.",
+      };
+    case "EMAIL_MISMATCH":
+      return {
+        title: "이메일 불일치",
+        description:
+          "이 초대는 다른 이메일 주소로 발송되었습니다. 초대받은 이메일 계정으로 로그인 후 다시 시도해주세요.",
+      };
+    default:
+      return {
+        title: "오류 발생",
+        description: "초대 수락 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.",
+      };
+  }
+}
+
+function InviteErrorCard({ code }: { code: string }) {
+  const { title, description } = getErrorContent(code);
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-slate-50 dark:bg-slate-900 px-4">
+      <div className="w-full max-w-sm text-center space-y-4">
+        <h1 className="text-xl font-semibold text-slate-900 dark:text-slate-50">{title}</h1>
+        <p className="text-sm text-slate-500 dark:text-slate-400">{description}</p>
+        <Link href="/" className="block text-sm text-blue-500 hover:text-blue-600">
+          홈으로 돌아가기
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+export default async function InviteAcceptPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ token?: string }>;
+}) {
+  const { token } = await searchParams;
+
+  if (!token) {
+    return <InviteErrorCard code="INVALID_TOKEN" />;
+  }
+
+  const supabase = await createServerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  // 미인증 → 로그인 후 이 페이지로 돌아오도록 next 파라미터 전달
+  if (!user || !user.email) {
+    redirect(`/login?next=/invite/accept?token=${token}`);
+  }
+
+  try {
+    const org = await OrgService.acceptInvitation(token, user.id, user.email);
+    redirect(`/org/${org.slug}`);
+  } catch (error) {
+    const code = error instanceof Error ? error.message : "ERROR";
+    return <InviteErrorCard code={code} />;
+  }
+}

--- a/apps/assassin/src/app/login/page.tsx
+++ b/apps/assassin/src/app/login/page.tsx
@@ -97,7 +97,10 @@ export default function LoginPage() {
           </form>
           <p className="mt-4 text-center text-sm text-slate-500 dark:text-slate-400">
             계정이 없으신가요?{" "}
-            <Link href="/signup" className="text-blue-500 hover:text-blue-600 font-medium">
+            <Link
+              href={next ? `/signup?next=${encodeURIComponent(next)}` : "/signup"}
+              className="text-blue-500 hover:text-blue-600 font-medium"
+            >
               회원가입
             </Link>
           </p>

--- a/apps/assassin/src/app/login/page.tsx
+++ b/apps/assassin/src/app/login/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { createBrowserSupabaseClient } from "@libs/supabase/client";
 import { Button } from "@/components/ui/button";
@@ -12,6 +12,8 @@ import { Loader2, Music } from "lucide-react";
 
 export default function LoginPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const next = searchParams.get("next");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
@@ -32,7 +34,7 @@ export default function LoginPage() {
     }
 
     router.refresh();
-    router.push("/");
+    router.push(next ?? "/");
   };
 
   return (

--- a/apps/assassin/src/app/login/page.tsx
+++ b/apps/assassin/src/app/login/page.tsx
@@ -33,7 +33,7 @@ export default function LoginPage() {
       return;
     }
 
-    router.refresh();
+    setIsLoading(false);
     router.push(next ?? "/");
   };
 

--- a/apps/assassin/src/app/org/[orgSlug]/settings/members/page.tsx
+++ b/apps/assassin/src/app/org/[orgSlug]/settings/members/page.tsx
@@ -29,7 +29,7 @@ export default async function SettingsMembersPage({ params }: Props) {
   ]);
 
   // OWNER만 접근 가능
-  const currentMember = members.find((m) => m.userId === user.id);
+  const currentMember = members.find((m: { userId: string }) => m.userId === user.id);
   if (currentMember?.role !== "OWNER") redirect(`/org/${orgSlug}`);
 
   return (

--- a/apps/assassin/src/app/org/[orgSlug]/settings/members/page.tsx
+++ b/apps/assassin/src/app/org/[orgSlug]/settings/members/page.tsx
@@ -1,17 +1,43 @@
-import { AppNav } from "@/components/navigation/AppNav";
+import { redirect } from "next/navigation";
+import { createServerSupabaseClient } from "@libs/supabase/server";
+import {
+  getOrgBySlugAction,
+  getOrgMembersAction,
+  getPendingInvitationsAction,
+} from "@features/org/actions";
+import { MembersPageClient } from "@features/org/components/MembersPageClient";
 
-export default function SettingsMembersPage() {
+interface Props {
+  params: Promise<{ orgSlug: string }>;
+}
+
+export default async function SettingsMembersPage({ params }: Props) {
+  const { orgSlug } = await params;
+
+  const supabase = await createServerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/");
+
+  const org = await getOrgBySlugAction(orgSlug).catch(() => null);
+  if (!org) redirect(`/org/${orgSlug}`);
+
+  const [members, pendingInvitations] = await Promise.all([
+    getOrgMembersAction(org.id).catch(() => []),
+    getPendingInvitationsAction(org.id).catch(() => []),
+  ]);
+
+  // OWNER만 접근 가능
+  const currentMember = members.find((m) => m.userId === user.id);
+  if (currentMember?.role !== "OWNER") redirect(`/org/${orgSlug}`);
+
   return (
-    <div className="h-screen bg-slate-50 dark:bg-slate-950 overflow-hidden">
-      <div className="w-full px-3 sm:px-6 lg:px-8 py-4 sm:py-6 h-full">
-        <div className="bg-white dark:bg-slate-900 rounded-lg p-4 sm:p-6 shadow-sm border border-slate-200 dark:border-slate-800 h-full flex flex-col min-h-0 overflow-y-auto">
-          <AppNav />
-          <div className="max-w-lg flex flex-col gap-4 pt-4">
-            <h1 className="text-xl font-semibold text-slate-900 dark:text-slate-50">멤버 관리</h1>
-            <p className="text-sm text-muted-foreground">멤버 관리 기능은 준비 중입니다.</p>
-          </div>
-        </div>
-      </div>
-    </div>
+    <MembersPageClient
+      org={org}
+      members={members}
+      pendingInvitations={pendingInvitations}
+      currentUserId={user.id}
+    />
   );
 }

--- a/apps/assassin/src/app/org/[orgSlug]/settings/page.tsx
+++ b/apps/assassin/src/app/org/[orgSlug]/settings/page.tsx
@@ -31,7 +31,7 @@ export default async function SettingsPage({ params }: Props) {
 
   const members = await getOrgMembersAction(org.id).catch(() => []);
   const currentMember = members.find((member: OrgMember) => member.userId === user.id);
-  if (currentMember?.role !== "OWNER") {
+  if (!currentMember) {
     redirect(`/org/${orgSlug}`);
   }
 

--- a/apps/assassin/src/app/signup/page.tsx
+++ b/apps/assassin/src/app/signup/page.tsx
@@ -55,7 +55,6 @@ export default function SignupPage() {
       return;
     }
 
-    router.refresh();
     router.push(next ?? "/");
   };
 
@@ -147,7 +146,10 @@ export default function SignupPage() {
           </form>
           <p className="mt-4 text-center text-sm text-slate-500 dark:text-slate-400">
             이미 계정이 있으신가요?{" "}
-            <Link href="/login" className="text-blue-500 hover:text-blue-600 font-medium">
+            <Link
+              href={next ? `/login?next=${encodeURIComponent(next)}` : "/login"}
+              className="text-blue-500 hover:text-blue-600 font-medium"
+            >
               로그인
             </Link>
           </p>

--- a/apps/assassin/src/app/signup/page.tsx
+++ b/apps/assassin/src/app/signup/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { createBrowserSupabaseClient } from "@libs/supabase/client";
 import { Button } from "@/components/ui/button";
@@ -12,6 +12,8 @@ import { Loader2, Music } from "lucide-react";
 
 export default function SignupPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const next = searchParams.get("next");
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -54,7 +56,7 @@ export default function SignupPage() {
     }
 
     router.refresh();
-    router.push("/");
+    router.push(next ?? "/");
   };
 
   return (

--- a/apps/assassin/src/components/navigation/LogoutButton.tsx
+++ b/apps/assassin/src/components/navigation/LogoutButton.tsx
@@ -15,7 +15,6 @@ export function LogoutButton() {
     setOpen(false);
     const supabase = createBrowserSupabaseClient();
     await supabase.auth.signOut();
-    router.refresh();
     router.push("/login");
   };
 

--- a/apps/assassin/src/components/navigation/NavOverflowMenu.tsx
+++ b/apps/assassin/src/components/navigation/NavOverflowMenu.tsx
@@ -20,7 +20,6 @@ export function NavOverflowMenu() {
 
     const supabase = createBrowserSupabaseClient();
     await supabase.auth.signOut();
-    router.refresh();
     router.push("/login");
   };
 

--- a/apps/assassin/src/components/navigation/TabNav.tsx
+++ b/apps/assassin/src/components/navigation/TabNav.tsx
@@ -8,7 +8,6 @@ export function TabNav() {
   const pathname = usePathname();
   const currentOrg = pathname.split("/")[2]; // Assuming URL structure is /org/[orgSlug]/...
   const role = useOrgRole();
-  const isOwner = role === "OWNER";
 
   return (
     <div className="flex min-w-0">
@@ -32,7 +31,7 @@ export function TabNav() {
       >
         Calendar
       </Link>
-      {isOwner && (
+      {role !== null && (
         <Link
           href={`/org/${currentOrg}/settings`}
           className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${

--- a/apps/assassin/src/features/org/actions.ts
+++ b/apps/assassin/src/features/org/actions.ts
@@ -130,6 +130,11 @@ export const removeMemberAction = async (orgId: string, targetUserId: string) =>
   await OrgService.removeMember(orgId, targetUserId, userId);
 };
 
+export const leaveOrgAction = async (orgId: string) => {
+  const userId = await getCurrentUserId();
+  await OrgService.leaveOrg(orgId, userId);
+};
+
 export const getPendingInvitationsAction = async (orgId: string) => {
   const userId = await getCurrentUserId();
   return await OrgService.getPendingInvitations(orgId, userId);

--- a/apps/assassin/src/features/org/actions.ts
+++ b/apps/assassin/src/features/org/actions.ts
@@ -68,26 +68,37 @@ export const inviteMemberAction = async (
     const userId = await getCurrentUserId();
     const invitation = await OrgService.inviteMember(orgId, userId, parsed.data);
 
-    // 이메일 발송에 필요한 조직명, 초대자 이름 조회
-    const [org, inviterProfile] = await Promise.all([
-      OrgService.getOrgById(orgId),
-      OrgService.getProfileById(userId),
-    ]);
+    let emailSent = false;
+    let emailError: string | undefined;
 
-    const emailResult = await sendInviteEmail({
-      to: invitation.email,
-      orgName: org?.name ?? orgId,
-      inviterName: inviterProfile?.name,
-      role: invitation.role,
-      expiresAt: invitation.expiresAt,
-      token: invitation.token,
-    });
+    try {
+      // 이메일 발송에 필요한 조직명, 초대자 이름 조회
+      const [org, inviterProfile] = await Promise.all([
+        OrgService.getOrgById(orgId),
+        OrgService.getProfileById(userId),
+      ]);
+
+      const emailResult = await sendInviteEmail({
+        to: invitation.email,
+        orgName: org?.name ?? orgId,
+        inviterName: inviterProfile?.name,
+        role: invitation.role,
+        expiresAt: invitation.expiresAt,
+        token: invitation.token,
+      });
+
+      emailSent = emailResult.sent;
+      emailError = emailResult.error;
+    } catch (error) {
+      emailSent = false;
+      emailError = error instanceof Error ? error.message : "이메일 발송 실패";
+    }
 
     return {
       success: true,
       data: { id: invitation.id, email: invitation.email, expiresAt: invitation.expiresAt },
-      emailSent: emailResult.sent,
-      ...(emailResult.error && { emailError: emailResult.error }),
+      emailSent,
+      ...(emailError && { emailError }),
     };
   } catch (error) {
     return {

--- a/apps/assassin/src/features/org/actions.ts
+++ b/apps/assassin/src/features/org/actions.ts
@@ -89,6 +89,9 @@ export const inviteMemberAction = async (
 
       emailSent = emailResult.sent;
       emailError = emailResult.error;
+      if (emailResult.sent) {
+        await OrgService.markInvitationEmailSent(invitation.id);
+      }
     } catch (error) {
       emailSent = false;
       emailError = error instanceof Error ? error.message : "이메일 발송 실패";

--- a/apps/assassin/src/features/org/actions.ts
+++ b/apps/assassin/src/features/org/actions.ts
@@ -98,8 +98,12 @@ export const inviteMemberAction = async (
 };
 
 export const acceptInvitationAction = async (token: string) => {
-  const userId = await getCurrentUserId();
-  return await OrgService.acceptInvitation(token, userId);
+  const supabase = await createServerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user || !user.email) throw new Error("인증이 필요합니다.");
+  return await OrgService.acceptInvitation(token, user.id, user.email);
 };
 
 export const cancelInvitationAction = async (invitationId: string, orgId: string) => {
@@ -110,4 +114,9 @@ export const cancelInvitationAction = async (invitationId: string, orgId: string
 export const removeMemberAction = async (orgId: string, targetUserId: string) => {
   const userId = await getCurrentUserId();
   await OrgService.removeMember(orgId, targetUserId, userId);
+};
+
+export const getPendingInvitationsAction = async (orgId: string) => {
+  const userId = await getCurrentUserId();
+  return await OrgService.getPendingInvitations(orgId, userId);
 };

--- a/apps/assassin/src/features/org/components/LeaveOrgButton.tsx
+++ b/apps/assassin/src/features/org/components/LeaveOrgButton.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { leaveOrgAction } from "../actions";
+
+export function LeaveOrgButton({ orgId }: { orgId: string }) {
+  const router = useRouter();
+  const [isLeaving, startLeaveTransition] = useTransition();
+
+  function handleLeave() {
+    startLeaveTransition(async () => {
+      await leaveOrgAction(orgId);
+      router.push("/");
+    });
+  }
+
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button size="sm" className="bg-red-500 hover:bg-red-600 text-white shrink-0">
+          조직 나가기
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>정말로 조직에서 나가시겠습니까?</AlertDialogTitle>
+          <AlertDialogDescription>
+            조직에서 나가면 더 이상 접근할 수 없습니다. 재참여하려면 다시 초대를 받아야 합니다.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>취소</AlertDialogCancel>
+          <Button
+            onClick={handleLeave}
+            disabled={isLeaving}
+            className="bg-red-500 hover:bg-red-600 text-white disabled:opacity-50"
+          >
+            {isLeaving ? "처리 중..." : "나가기"}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/assassin/src/features/org/components/MembersPageClient.tsx
+++ b/apps/assassin/src/features/org/components/MembersPageClient.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { AppNav } from "@/components/navigation/AppNav";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
+import { inviteMemberAction, cancelInvitationAction, removeMemberAction } from "../actions";
+
+type MemberWithProfile = {
+  id: string;
+  userId: string;
+  role: string;
+  profile: { name: string; realName: string } | null;
+};
+
+type PendingInvitation = {
+  id: string;
+  email: string;
+  expiresAt: Date;
+};
+
+type Org = {
+  id: string;
+  name: string;
+  slug: string;
+};
+
+interface Props {
+  org: Org;
+  members: MemberWithProfile[];
+  pendingInvitations: PendingInvitation[];
+  currentUserId: string;
+}
+
+export function MembersPageClient({ org, members, pendingInvitations, currentUserId }: Props) {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [inviteError, setInviteError] = useState<string | null>(null);
+  const [inviteWarning, setInviteWarning] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const handleInvite = (e: React.FormEvent) => {
+    e.preventDefault();
+    setInviteError(null);
+    setInviteWarning(null);
+
+    startTransition(async () => {
+      const result = await inviteMemberAction(org.id, { email, role: "MEMBER" });
+      if (!result.success) {
+        setInviteError(result.error);
+        return;
+      }
+      setEmail("");
+      if (!result.emailSent) {
+        setInviteWarning(
+          `초대가 생성되었지만 이메일 발송에 실패했습니다. (${result.emailError ?? "알 수 없는 오류"})`,
+        );
+      }
+      router.refresh();
+    });
+  };
+
+  const handleCancelInvitation = (invitationId: string) => {
+    startTransition(async () => {
+      await cancelInvitationAction(invitationId, org.id);
+      router.refresh();
+    });
+  };
+
+  const handleRemoveMember = (targetUserId: string) => {
+    startTransition(async () => {
+      await removeMemberAction(org.id, targetUserId);
+      router.refresh();
+    });
+  };
+
+  return (
+    <div className="h-screen bg-slate-50 dark:bg-slate-950 overflow-hidden">
+      <div className="w-full px-3 sm:px-6 lg:px-8 py-4 sm:py-6 h-full">
+        <div className="bg-white dark:bg-slate-900 rounded-lg p-4 sm:p-6 shadow-sm border border-slate-200 dark:border-slate-800 h-full flex flex-col min-h-0 overflow-y-auto">
+          <AppNav />
+
+          <div className="max-w-lg flex flex-col gap-8 pt-4">
+            <h1 className="text-xl font-semibold text-slate-900 dark:text-slate-50">멤버 관리</h1>
+
+            {/* 초대 폼 */}
+            <section className="flex flex-col gap-4">
+              <h2 className="text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wider">
+                멤버 초대
+              </h2>
+              <form onSubmit={handleInvite} className="flex flex-col gap-1.5">
+                <Label htmlFor="invite-email" className="text-slate-700 dark:text-slate-300">
+                  이메일
+                </Label>
+                <div className="flex gap-2">
+                  <Input
+                    id="invite-email"
+                    type="email"
+                    placeholder="name@example.com"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    required
+                    disabled={isPending}
+                    className="bg-white dark:bg-slate-900 border-slate-200 dark:border-slate-700"
+                  />
+                  <Button
+                    type="submit"
+                    disabled={isPending || !email}
+                    className="bg-blue-500 hover:bg-blue-600 text-white shrink-0"
+                  >
+                    {isPending ? "전송 중..." : "초대"}
+                  </Button>
+                </div>
+                {inviteError && <p className="text-sm text-red-500">{inviteError}</p>}
+                {inviteWarning && <p className="text-sm text-yellow-600">{inviteWarning}</p>}
+              </form>
+            </section>
+
+            <Separator />
+
+            {/* 대기 중인 초대 */}
+            {pendingInvitations.length > 0 && (
+              <>
+                <section className="flex flex-col gap-4">
+                  <h2 className="text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wider">
+                    초대 대기 중 ({pendingInvitations.length})
+                  </h2>
+                  <ul className="flex flex-col gap-2">
+                    {pendingInvitations.map((inv) => (
+                      <li
+                        key={inv.id}
+                        className="flex items-center justify-between rounded-lg border border-slate-200 dark:border-slate-800 px-4 py-3"
+                      >
+                        <div>
+                          <p className="text-sm font-medium text-slate-900 dark:text-slate-50">
+                            {inv.email}
+                          </p>
+                          <p className="text-xs text-slate-500 dark:text-slate-400">
+                            만료: {new Date(inv.expiresAt).toLocaleDateString("ko-KR")}
+                          </p>
+                        </div>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          disabled={isPending}
+                          onClick={() => handleCancelInvitation(inv.id)}
+                          className="text-red-500 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-950"
+                        >
+                          취소
+                        </Button>
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+                <Separator />
+              </>
+            )}
+
+            {/* 멤버 목록 */}
+            <section className="flex flex-col gap-4">
+              <h2 className="text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wider">
+                멤버 ({members.length})
+              </h2>
+              <ul className="flex flex-col gap-2">
+                {members.map((member) => (
+                  <li
+                    key={member.id}
+                    className="flex items-center justify-between rounded-lg border border-slate-200 dark:border-slate-800 px-4 py-3"
+                  >
+                    <div>
+                      <p className="text-sm font-medium text-slate-900 dark:text-slate-50">
+                        {member.profile?.name ?? "알 수 없음"}
+                      </p>
+                      <p className="text-xs text-slate-500 dark:text-slate-400">
+                        {member.role === "OWNER" ? "오너" : "멤버"}
+                      </p>
+                    </div>
+                    {member.role !== "OWNER" && member.userId !== currentUserId && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        disabled={isPending}
+                        onClick={() => handleRemoveMember(member.userId)}
+                        className="text-red-500 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-950"
+                      >
+                        제거
+                      </Button>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </section>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/assassin/src/features/org/components/MembersPageClient.tsx
+++ b/apps/assassin/src/features/org/components/MembersPageClient.tsx
@@ -20,6 +20,7 @@ type PendingInvitation = {
   id: string;
   email: string;
   expiresAt: Date;
+  emailSentAt: Date | null;
 };
 
 type Org = {
@@ -161,6 +162,11 @@ export function MembersPageClient({ org, members, pendingInvitations, currentUse
                           <p className="text-xs text-slate-500 dark:text-slate-400">
                             만료: {new Date(inv.expiresAt).toLocaleDateString("ko-KR")}
                           </p>
+                          {!inv.emailSentAt && (
+                            <p className="text-xs text-yellow-600 dark:text-yellow-500 mt-0.5">
+                              이메일 미발송
+                            </p>
+                          )}
                         </div>
                         <div className="flex items-center gap-2">
                           <Button
@@ -170,7 +176,7 @@ export function MembersPageClient({ org, members, pendingInvitations, currentUse
                             onClick={() => handleResendInvitation(inv.email)}
                             className="text-slate-700 border-slate-300 hover:bg-slate-100 dark:text-slate-200 dark:border-slate-700 dark:hover:bg-slate-800"
                           >
-                            이메일 재발송
+                            {inv.emailSentAt ? "이메일 재발송" : "이메일 발송"}
                           </Button>
                           <Button
                             variant="ghost"

--- a/apps/assassin/src/features/org/components/MembersPageClient.tsx
+++ b/apps/assassin/src/features/org/components/MembersPageClient.tsx
@@ -70,6 +70,26 @@ export function MembersPageClient({ org, members, pendingInvitations, currentUse
     });
   };
 
+  const handleResendInvitation = (targetEmail: string) => {
+    setInviteError(null);
+    setInviteWarning(null);
+
+    startTransition(async () => {
+      const result = await inviteMemberAction(org.id, { email: targetEmail, role: "MEMBER" });
+      if (!result.success) {
+        setInviteError(result.error);
+        return;
+      }
+
+      if (!result.emailSent) {
+        setInviteWarning(
+          `재발송 초대가 생성되었지만 이메일 발송에 실패했습니다. (${result.emailError ?? "알 수 없는 오류"})`,
+        );
+      }
+      router.refresh();
+    });
+  };
+
   const handleRemoveMember = (targetUserId: string) => {
     startTransition(async () => {
       await removeMemberAction(org.id, targetUserId);
@@ -142,15 +162,26 @@ export function MembersPageClient({ org, members, pendingInvitations, currentUse
                             만료: {new Date(inv.expiresAt).toLocaleDateString("ko-KR")}
                           </p>
                         </div>
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          disabled={isPending}
-                          onClick={() => handleCancelInvitation(inv.id)}
-                          className="text-red-500 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-950"
-                        >
-                          취소
-                        </Button>
+                        <div className="flex items-center gap-2">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            disabled={isPending}
+                            onClick={() => handleResendInvitation(inv.email)}
+                            className="text-slate-700 border-slate-300 hover:bg-slate-100 dark:text-slate-200 dark:border-slate-700 dark:hover:bg-slate-800"
+                          >
+                            이메일 재발송
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            disabled={isPending}
+                            onClick={() => handleCancelInvitation(inv.id)}
+                            className="text-red-500 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-950"
+                          >
+                            취소
+                          </Button>
+                        </div>
                       </li>
                     ))}
                   </ul>

--- a/apps/assassin/src/features/org/components/MembersPageClient.tsx
+++ b/apps/assassin/src/features/org/components/MembersPageClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useState, useTransition, useOptimistic } from "react";
 import { useRouter } from "next/navigation";
 import { AppNav } from "@/components/navigation/AppNav";
 import { Button } from "@/components/ui/button";
@@ -42,6 +42,17 @@ export function MembersPageClient({ org, members, pendingInvitations, currentUse
   const [inviteError, setInviteError] = useState<string | null>(null);
   const [inviteWarning, setInviteWarning] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
+  const [optimisticInvitations, addOptimisticInvitation] = useOptimistic(
+    pendingInvitations,
+    (
+      state,
+      action: { type: "add"; invitation: PendingInvitation } | { type: "remove"; id: string },
+    ) => {
+      if (action.type === "add") return [...state, action.invitation];
+      if (action.type === "remove") return state.filter((inv) => inv.id !== action.id);
+      return state;
+    },
+  );
 
   const handleInvite = (e: React.FormEvent) => {
     e.preventDefault();
@@ -54,6 +65,15 @@ export function MembersPageClient({ org, members, pendingInvitations, currentUse
         setInviteError(result.error);
         return;
       }
+      addOptimisticInvitation({
+        type: "add",
+        invitation: {
+          id: result.data.id,
+          email: result.data.email,
+          expiresAt: result.data.expiresAt,
+          emailSentAt: result.emailSent ? new Date() : null,
+        },
+      });
       setEmail("");
       if (!result.emailSent) {
         setInviteWarning(
@@ -66,6 +86,7 @@ export function MembersPageClient({ org, members, pendingInvitations, currentUse
 
   const handleCancelInvitation = (invitationId: string) => {
     startTransition(async () => {
+      addOptimisticInvitation({ type: "remove", id: invitationId });
       await cancelInvitationAction(invitationId, org.id);
       router.refresh();
     });
@@ -143,14 +164,14 @@ export function MembersPageClient({ org, members, pendingInvitations, currentUse
             <Separator />
 
             {/* 대기 중인 초대 */}
-            {pendingInvitations.length > 0 && (
+            {optimisticInvitations.length > 0 && (
               <>
                 <section className="flex flex-col gap-4">
                   <h2 className="text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wider">
-                    초대 대기 중 ({pendingInvitations.length})
+                    초대 대기 중 ({optimisticInvitations.length})
                   </h2>
                   <ul className="flex flex-col gap-2">
-                    {pendingInvitations.map((inv) => (
+                    {optimisticInvitations.map((inv) => (
                       <li
                         key={inv.id}
                         className="flex items-center justify-between rounded-lg border border-slate-200 dark:border-slate-800 px-4 py-3"

--- a/apps/assassin/src/features/org/components/OrgSelectPageClient.tsx
+++ b/apps/assassin/src/features/org/components/OrgSelectPageClient.tsx
@@ -6,6 +6,7 @@ import type { Org } from "@/features/org/schema";
 import { useRealtimeOrgSync } from "@/features/org/hooks/useRealtimeOrgSync";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { LogoutButton } from "@/components/navigation/LogoutButton";
 
 interface OrgSelectPageClientProps {
   orgs: Org[];
@@ -49,6 +50,7 @@ export function OrgSelectPageClient({ orgs }: OrgSelectPageClientProps) {
           <Button asChild className="w-full bg-blue-500 hover:bg-blue-600 text-white">
             <Link href="/org/create">새 조직 만들기</Link>
           </Button>
+          <LogoutButton />
         </CardContent>
       </Card>
     </div>

--- a/apps/assassin/src/features/org/components/OrgSettingsPageClient.tsx
+++ b/apps/assassin/src/features/org/components/OrgSettingsPageClient.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { FormEvent, useState, useTransition } from "react";
+import { FormEvent, useState } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 import { AppNav } from "@/components/navigation/AppNav";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -13,7 +12,7 @@ import { useOrgBySlug } from "@/features/org/queries/useOrgBySlug";
 import { useOrgRole } from "@libs/org/OrgProvider";
 import { useUpdateOrg } from "../mutations/useUpdateOrg";
 import { DeleteOrgButton } from "./DeleteOrgButton";
-import { leaveOrgAction } from "../actions";
+import { LeaveOrgButton } from "./LeaveOrgButton";
 
 interface OrgSettingsPageClientProps {
   orgSlug: string;
@@ -26,9 +25,6 @@ export function OrgSettingsPageClient({ orgSlug }: OrgSettingsPageClientProps) {
   const updateOrgMutation = useUpdateOrg();
   const role = useOrgRole();
   const isOwner = role === "OWNER";
-  const router = useRouter();
-  const [isLeaving, startLeaveTransition] = useTransition();
-
   useRealtimeOrgSync(org.id);
 
   const isSameName = name.trim() === org.name;
@@ -56,6 +52,9 @@ export function OrgSettingsPageClient({ orgSlug }: OrgSettingsPageClientProps) {
 
             {!isOwner && (
               <section className="flex flex-col gap-4">
+                <h2 className="text-xs font-medium text-red-500 uppercase tracking-wider">
+                  위험 구역
+                </h2>
                 <div className="rounded-lg border border-red-200 dark:border-red-900/60 p-4 flex items-center justify-between gap-4">
                   <div>
                     <p className="text-sm font-medium text-slate-900 dark:text-slate-50">조직 나가기</p>
@@ -63,20 +62,7 @@ export function OrgSettingsPageClient({ orgSlug }: OrgSettingsPageClientProps) {
                       조직에서 나가면 더 이상 접근할 수 없습니다.
                     </p>
                   </div>
-                  <Button
-                    variant="destructive"
-                    size="sm"
-                    disabled={isLeaving}
-                    onClick={() => {
-                      if (!confirm("정말 조직에서 나가시겠습니까?")) return;
-                      startLeaveTransition(async () => {
-                        await leaveOrgAction(org.id);
-                        router.push("/");
-                      });
-                    }}
-                  >
-                    {isLeaving ? "처리 중..." : "조직 나가기"}
-                  </Button>
+                  <LeaveOrgButton orgId={org.id} />
                 </div>
               </section>
             )}

--- a/apps/assassin/src/features/org/components/OrgSettingsPageClient.tsx
+++ b/apps/assassin/src/features/org/components/OrgSettingsPageClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FormEvent, useState } from "react";
+import { FormEvent, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { AppNav } from "@/components/navigation/AppNav";
 import { Button } from "@/components/ui/button";
@@ -28,6 +28,14 @@ export function OrgSettingsPageClient({ orgSlug }: OrgSettingsPageClientProps) {
   useRealtimeOrgSync(org.id);
 
   const isSameName = name.trim() === org.name;
+  const [savedFeedback, setSavedFeedback] = useState(false);
+  const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
+    };
+  }, []);
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -39,6 +47,8 @@ export function OrgSettingsPageClient({ orgSlug }: OrgSettingsPageClientProps) {
       data: { name: nextName },
     });
     setEditedName(null);
+    setSavedFeedback(true);
+    savedTimerRef.current = setTimeout(() => setSavedFeedback(false), 2000);
   };
 
   return (
@@ -52,12 +62,12 @@ export function OrgSettingsPageClient({ orgSlug }: OrgSettingsPageClientProps) {
 
             {!isOwner && (
               <section className="flex flex-col gap-4">
-                <h2 className="text-xs font-medium text-red-500 uppercase tracking-wider">
-                  주의
-                </h2>
+                <h2 className="text-xs font-medium text-red-500 uppercase tracking-wider">주의</h2>
                 <div className="rounded-lg border border-red-200 dark:border-red-900/60 p-4 flex items-center justify-between gap-4">
                   <div>
-                    <p className="text-sm font-medium text-slate-900 dark:text-slate-50">조직 나가기</p>
+                    <p className="text-sm font-medium text-slate-900 dark:text-slate-50">
+                      조직 나가기
+                    </p>
                     <p className="text-sm text-muted-foreground mt-0.5">
                       조직에서 나가면 더 이상 접근할 수 없습니다.
                     </p>
@@ -93,7 +103,11 @@ export function OrgSettingsPageClient({ orgSlug }: OrgSettingsPageClientProps) {
                         disabled={isSameName || updateOrgMutation.isPending}
                         className="bg-blue-500 hover:bg-blue-600 text-white"
                       >
-                        {updateOrgMutation.isPending ? "저장 중..." : "저장"}
+                        {updateOrgMutation.isPending
+                          ? "저장 중..."
+                          : savedFeedback
+                            ? "저장됨 ✓"
+                            : "저장"}
                       </Button>
                     </div>
                   </form>
@@ -107,7 +121,9 @@ export function OrgSettingsPageClient({ orgSlug }: OrgSettingsPageClientProps) {
                   </h2>
                   <div className="rounded-lg border border-slate-200 dark:border-slate-800 p-4 flex items-center justify-between gap-4">
                     <div>
-                      <p className="text-sm font-medium text-slate-900 dark:text-slate-50">멤버 관리</p>
+                      <p className="text-sm font-medium text-slate-900 dark:text-slate-50">
+                        멤버 관리
+                      </p>
                       <p className="text-sm text-muted-foreground mt-0.5">
                         멤버 초대, 재발송, 제거를 관리합니다.
                       </p>
@@ -126,7 +142,9 @@ export function OrgSettingsPageClient({ orgSlug }: OrgSettingsPageClientProps) {
                   </h2>
                   <div className="rounded-lg border border-red-200 dark:border-red-900/60 p-4 flex items-center justify-between gap-4">
                     <div>
-                      <p className="text-sm font-medium text-slate-900 dark:text-slate-50">조직 삭제</p>
+                      <p className="text-sm font-medium text-slate-900 dark:text-slate-50">
+                        조직 삭제
+                      </p>
                       <p className="text-sm text-muted-foreground mt-0.5">
                         삭제하면 모든 데이터가 영구적으로 제거됩니다.
                       </p>

--- a/apps/assassin/src/features/org/components/OrgSettingsPageClient.tsx
+++ b/apps/assassin/src/features/org/components/OrgSettingsPageClient.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { FormEvent, useState } from "react";
+import { FormEvent, useState, useTransition } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { AppNav } from "@/components/navigation/AppNav";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -9,8 +10,10 @@ import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 import { useRealtimeOrgSync } from "@/features/org/hooks/useRealtimeOrgSync";
 import { useOrgBySlug } from "@/features/org/queries/useOrgBySlug";
+import { useOrgRole } from "@libs/org/OrgProvider";
 import { useUpdateOrg } from "../mutations/useUpdateOrg";
 import { DeleteOrgButton } from "./DeleteOrgButton";
+import { leaveOrgAction } from "../actions";
 
 interface OrgSettingsPageClientProps {
   orgSlug: string;
@@ -21,6 +24,10 @@ export function OrgSettingsPageClient({ orgSlug }: OrgSettingsPageClientProps) {
   const [editedName, setEditedName] = useState<string | null>(null);
   const name = editedName ?? org.name;
   const updateOrgMutation = useUpdateOrg();
+  const role = useOrgRole();
+  const isOwner = role === "OWNER";
+  const router = useRouter();
+  const [isLeaving, startLeaveTransition] = useTransition();
 
   useRealtimeOrgSync(org.id);
 
@@ -47,71 +54,102 @@ export function OrgSettingsPageClient({ orgSlug }: OrgSettingsPageClientProps) {
           <div className="max-w-lg flex flex-col gap-8 pt-4">
             <h1 className="text-xl font-semibold text-slate-900 dark:text-slate-50">설정</h1>
 
-            <section className="flex flex-col gap-4">
-              <h2 className="text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wider">
-                일반
-              </h2>
-              <form onSubmit={handleSubmit} className="flex flex-col gap-1.5">
-                <Label htmlFor="name" className="text-slate-700 dark:text-slate-300">
-                  조직 이름
-                </Label>
-                <div className="flex gap-2">
-                  <Input
-                    id="name"
-                    name="name"
-                    type="text"
-                    required
-                    maxLength={100}
-                    value={name}
-                    onChange={(e) => setEditedName(e.target.value)}
-                    className="bg-white dark:bg-slate-900 border-slate-200 dark:border-slate-700"
-                  />
+            {!isOwner && (
+              <section className="flex flex-col gap-4">
+                <div className="rounded-lg border border-red-200 dark:border-red-900/60 p-4 flex items-center justify-between gap-4">
+                  <div>
+                    <p className="text-sm font-medium text-slate-900 dark:text-slate-50">조직 나가기</p>
+                    <p className="text-sm text-muted-foreground mt-0.5">
+                      조직에서 나가면 더 이상 접근할 수 없습니다.
+                    </p>
+                  </div>
                   <Button
-                    type="submit"
-                    disabled={isSameName || updateOrgMutation.isPending}
-                    className="bg-blue-500 hover:bg-blue-600 text-white"
+                    variant="destructive"
+                    size="sm"
+                    disabled={isLeaving}
+                    onClick={() => {
+                      if (!confirm("정말 조직에서 나가시겠습니까?")) return;
+                      startLeaveTransition(async () => {
+                        await leaveOrgAction(org.id);
+                        router.push("/");
+                      });
+                    }}
                   >
-                    {updateOrgMutation.isPending ? "저장 중..." : "저장"}
+                    {isLeaving ? "처리 중..." : "조직 나가기"}
                   </Button>
                 </div>
-              </form>
-            </section>
+              </section>
+            )}
 
-            <Separator />
+            {isOwner && (
+              <>
+                <section className="flex flex-col gap-4">
+                  <h2 className="text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wider">
+                    일반
+                  </h2>
+                  <form onSubmit={handleSubmit} className="flex flex-col gap-1.5">
+                    <Label htmlFor="name" className="text-slate-700 dark:text-slate-300">
+                      조직 이름
+                    </Label>
+                    <div className="flex gap-2">
+                      <Input
+                        id="name"
+                        name="name"
+                        type="text"
+                        required
+                        maxLength={100}
+                        value={name}
+                        onChange={(e) => setEditedName(e.target.value)}
+                        className="bg-white dark:bg-slate-900 border-slate-200 dark:border-slate-700"
+                      />
+                      <Button
+                        type="submit"
+                        disabled={isSameName || updateOrgMutation.isPending}
+                        className="bg-blue-500 hover:bg-blue-600 text-white"
+                      >
+                        {updateOrgMutation.isPending ? "저장 중..." : "저장"}
+                      </Button>
+                    </div>
+                  </form>
+                </section>
 
-            <section className="flex flex-col gap-4">
-              <h2 className="text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wider">
-                멤버
-              </h2>
-              <div className="rounded-lg border border-slate-200 dark:border-slate-800 p-4 flex items-center justify-between gap-4">
-                <div>
-                  <p className="text-sm font-medium text-slate-900 dark:text-slate-50">멤버 관리</p>
-                  <p className="text-sm text-muted-foreground mt-0.5">
-                    멤버 초대, 재발송, 제거를 관리합니다.
-                  </p>
-                </div>
-                <Button asChild className="bg-blue-500 hover:bg-blue-600 text-white">
-                  <Link href={`/org/${orgSlug}/settings/members`}>멤버 설정으로 이동</Link>
-                </Button>
-              </div>
-            </section>
+                <Separator />
 
-            <Separator />
+                <section className="flex flex-col gap-4">
+                  <h2 className="text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wider">
+                    멤버
+                  </h2>
+                  <div className="rounded-lg border border-slate-200 dark:border-slate-800 p-4 flex items-center justify-between gap-4">
+                    <div>
+                      <p className="text-sm font-medium text-slate-900 dark:text-slate-50">멤버 관리</p>
+                      <p className="text-sm text-muted-foreground mt-0.5">
+                        멤버 초대, 재발송, 제거를 관리합니다.
+                      </p>
+                    </div>
+                    <Button asChild className="bg-blue-500 hover:bg-blue-600 text-white">
+                      <Link href={`/org/${orgSlug}/settings/members`}>멤버 설정으로 이동</Link>
+                    </Button>
+                  </div>
+                </section>
 
-            <section className="flex flex-col gap-4">
-              <h2 className="text-xs font-medium text-red-500 uppercase tracking-wider">
-                위험 구역
-              </h2>
-              <div className="rounded-lg border border-red-200 dark:border-red-900/60 p-4 flex items-center justify-between gap-4">
-                <div>
-                  <p className="text-sm font-medium text-slate-900 dark:text-slate-50">조직 삭제</p>
-                  <p className="text-sm text-muted-foreground mt-0.5">
-                    삭제하면 모든 데이터가 영구적으로 제거됩니다.
-                  </p>
-                </div>
-                <DeleteOrgButton orgId={org.id} orgName={org.name} />
-              </div>
-            </section>
+                <Separator />
+
+                <section className="flex flex-col gap-4">
+                  <h2 className="text-xs font-medium text-red-500 uppercase tracking-wider">
+                    위험 구역
+                  </h2>
+                  <div className="rounded-lg border border-red-200 dark:border-red-900/60 p-4 flex items-center justify-between gap-4">
+                    <div>
+                      <p className="text-sm font-medium text-slate-900 dark:text-slate-50">조직 삭제</p>
+                      <p className="text-sm text-muted-foreground mt-0.5">
+                        삭제하면 모든 데이터가 영구적으로 제거됩니다.
+                      </p>
+                    </div>
+                    <DeleteOrgButton orgId={org.id} orgName={org.name} />
+                  </div>
+                </section>
+              </>
+            )}
           </div>
         </div>
       </div>

--- a/apps/assassin/src/features/org/components/OrgSettingsPageClient.tsx
+++ b/apps/assassin/src/features/org/components/OrgSettingsPageClient.tsx
@@ -53,7 +53,7 @@ export function OrgSettingsPageClient({ orgSlug }: OrgSettingsPageClientProps) {
             {!isOwner && (
               <section className="flex flex-col gap-4">
                 <h2 className="text-xs font-medium text-red-500 uppercase tracking-wider">
-                  위험 구역
+                  주의
                 </h2>
                 <div className="rounded-lg border border-red-200 dark:border-red-900/60 p-4 flex items-center justify-between gap-4">
                   <div>
@@ -122,7 +122,7 @@ export function OrgSettingsPageClient({ orgSlug }: OrgSettingsPageClientProps) {
 
                 <section className="flex flex-col gap-4">
                   <h2 className="text-xs font-medium text-red-500 uppercase tracking-wider">
-                    위험 구역
+                    주의
                   </h2>
                   <div className="rounded-lg border border-red-200 dark:border-red-900/60 p-4 flex items-center justify-between gap-4">
                     <div>

--- a/apps/assassin/src/features/org/components/OrgSettingsPageClient.tsx
+++ b/apps/assassin/src/features/org/components/OrgSettingsPageClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { FormEvent, useState } from "react";
+import Link from "next/link";
 import { AppNav } from "@/components/navigation/AppNav";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -74,6 +75,25 @@ export function OrgSettingsPageClient({ orgSlug }: OrgSettingsPageClientProps) {
                   </Button>
                 </div>
               </form>
+            </section>
+
+            <Separator />
+
+            <section className="flex flex-col gap-4">
+              <h2 className="text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wider">
+                멤버
+              </h2>
+              <div className="rounded-lg border border-slate-200 dark:border-slate-800 p-4 flex items-center justify-between gap-4">
+                <div>
+                  <p className="text-sm font-medium text-slate-900 dark:text-slate-50">멤버 관리</p>
+                  <p className="text-sm text-muted-foreground mt-0.5">
+                    멤버 초대, 재발송, 제거를 관리합니다.
+                  </p>
+                </div>
+                <Button asChild className="bg-blue-500 hover:bg-blue-600 text-white">
+                  <Link href={`/org/${orgSlug}/settings/members`}>멤버 설정으로 이동</Link>
+                </Button>
+              </div>
             </section>
 
             <Separator />

--- a/apps/assassin/src/features/org/repository.ts
+++ b/apps/assassin/src/features/org/repository.ts
@@ -109,7 +109,7 @@ async function getInvitationByToken(token: string) {
 
 async function getPendingInvitationsByOrg(orgId: string) {
   return await prisma.orgInvitation.findMany({
-    where: { orgId, status: "PENDING" },
+    where: { orgId, status: "PENDING", expiresAt: { gt: new Date() } },
   });
 }
 

--- a/apps/assassin/src/features/org/repository.ts
+++ b/apps/assassin/src/features/org/repository.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@libs/prisma/client";
-import { Prisma } from "@prisma/client";
+import { Prisma } from "../../generated/prisma/client";
 import { CreateOrgPayload, UpdateOrgPayload } from "./schema";
 import crypto from "crypto";
 
@@ -42,7 +42,12 @@ async function deleteOrg(id: string) {
 }
 
 // OrgMember
-async function addMember(orgId: string, userId: string, role: "OWNER" | "MEMBER", tx?: Prisma.TransactionClient) {
+async function addMember(
+  orgId: string,
+  userId: string,
+  role: "OWNER" | "MEMBER",
+  tx?: Prisma.TransactionClient,
+) {
   const client = tx ?? prisma;
   return await client.orgMember.create({
     data: { orgId, userId, role },
@@ -76,7 +81,12 @@ async function removeMember(orgId: string, userId: string) {
 }
 
 // OrgInvitation
-async function createInvitation(orgId: string, email: string, role: "MEMBER", tx?: Prisma.TransactionClient) {
+async function createInvitation(
+  orgId: string,
+  email: string,
+  role: "MEMBER",
+  tx?: Prisma.TransactionClient,
+) {
   const token = crypto.randomBytes(32).toString("hex");
   const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000); // 7일
   const client = tx ?? prisma;
@@ -103,7 +113,11 @@ async function getPendingInvitationsByOrg(orgId: string) {
   });
 }
 
-async function updateInvitationStatus(id: string, status: "ACCEPTED" | "EXPIRED" | "CANCELLED", tx?: Prisma.TransactionClient) {
+async function updateInvitationStatus(
+  id: string,
+  status: "ACCEPTED" | "EXPIRED" | "CANCELLED",
+  tx?: Prisma.TransactionClient,
+) {
   const client = tx ?? prisma;
   return await client.orgInvitation.update({
     where: { id },
@@ -123,8 +137,19 @@ async function findUserIdByEmail(email: string): Promise<string | null> {
   return rows[0]?.id ?? null;
 }
 
+async function markInvitationEmailSent(id: string): Promise<void> {
+  await prisma.orgInvitation.update({
+    where: { id },
+    data: { emailSentAt: new Date() },
+  });
+}
+
 // 동일 (orgId, email)의 PENDING 초대를 모두 취소 — 재초대 시 호출
-async function cancelPendingInvitationsByEmail(orgId: string, email: string, tx?: Prisma.TransactionClient): Promise<void> {
+async function cancelPendingInvitationsByEmail(
+  orgId: string,
+  email: string,
+  tx?: Prisma.TransactionClient,
+): Promise<void> {
   const client = tx ?? prisma;
   await client.orgInvitation.updateMany({
     where: { orgId, email, status: "PENDING" },
@@ -150,6 +175,7 @@ const OrgRepository = {
   updateInvitationStatus,
   findUserIdByEmail,
   cancelPendingInvitationsByEmail,
+  markInvitationEmailSent,
   getProfileById,
 };
 

--- a/apps/assassin/src/features/org/service.ts
+++ b/apps/assassin/src/features/org/service.ts
@@ -88,15 +88,13 @@ const acceptInvitation = async (token: string, userId: string, userEmail: string
     throw new Error("EMAIL_MISMATCH");
   }
 
-  // 멱등성: 이미 멤버라면 중복 생성하지 않음
-  const existingMember = await OrgRepository.getMember(invitation.orgId, userId);
-  if (!existingMember) {
-    await OrgRepository.addMember(invitation.orgId, userId, "MEMBER");
-  }
-
   // 멤버 추가와 초대 상태 업데이트를 트랜잭션으로 묶어 원자성 보장
+  // 멱등성: 트랜잭션 안에서 이미 멤버인지 확인 후 추가
   await prisma.$transaction(async (tx) => {
-    await OrgRepository.addMember(invitation.orgId, userId, "MEMBER", tx);
+    const existingMember = await OrgRepository.getMember(invitation.orgId, userId);
+    if (!existingMember) {
+      await OrgRepository.addMember(invitation.orgId, userId, "MEMBER", tx);
+    }
     await OrgRepository.updateInvitationStatus(invitation.id, "ACCEPTED", tx);
   });
 
@@ -120,6 +118,10 @@ const removeMember = async (orgId: string, targetUserId: string, requesterId: st
   await OrgRepository.removeMember(orgId, targetUserId);
 };
 
+const markInvitationEmailSent = async (invitationId: string) => {
+  await OrgRepository.markInvitationEmailSent(invitationId);
+};
+
 const getProfileById = async (userId: string) => {
   return await OrgRepository.getProfileById(userId);
 };
@@ -141,6 +143,7 @@ const OrgService = {
   acceptInvitation,
   cancelInvitation,
   removeMember,
+  markInvitationEmailSent,
   getProfileById,
   getPendingInvitations,
 };

--- a/apps/assassin/src/features/org/service.ts
+++ b/apps/assassin/src/features/org/service.ts
@@ -68,20 +68,30 @@ const inviteMember = async (orgId: string, requesterId: string, input: InviteMem
   });
 };
 
-const acceptInvitation = async (token: string, userId: string) => {
+const acceptInvitation = async (token: string, userId: string, userEmail: string) => {
   const invitation = await OrgRepository.getInvitationByToken(token);
 
-  if (!invitation) {
-    throw new Error("유효하지 않은 초대 토큰입니다.");
+  if (!invitation) throw new Error("INVALID_TOKEN");
+
+  // 상태별 명시적 에러 코드
+  if (invitation.status === "ACCEPTED") throw new Error("ALREADY_ACCEPTED");
+  if (invitation.status === "CANCELLED") throw new Error("REVOKED");
+  if (invitation.status === "EXPIRED" || new Date() > invitation.expiresAt) {
+    if (invitation.status !== "EXPIRED") {
+      await OrgRepository.updateInvitationStatus(invitation.id, "EXPIRED");
+    }
+    throw new Error("EXPIRED");
   }
 
-  if (invitation.status !== "PENDING") {
-    throw new Error("이미 처리된 초대입니다.");
+  // 초대 이메일과 로그인한 유저 이메일 정확히 일치해야 함
+  if (invitation.email !== userEmail.toLowerCase().trim()) {
+    throw new Error("EMAIL_MISMATCH");
   }
 
-  if (new Date() > invitation.expiresAt) {
-    await OrgRepository.updateInvitationStatus(invitation.id, "EXPIRED");
-    throw new Error("만료된 초대입니다.");
+  // 멱등성: 이미 멤버라면 중복 생성하지 않음
+  const existingMember = await OrgRepository.getMember(invitation.orgId, userId);
+  if (!existingMember) {
+    await OrgRepository.addMember(invitation.orgId, userId, "MEMBER");
   }
 
   // 멤버 추가와 초대 상태 업데이트를 트랜잭션으로 묶어 원자성 보장
@@ -90,7 +100,8 @@ const acceptInvitation = async (token: string, userId: string) => {
     await OrgRepository.updateInvitationStatus(invitation.id, "ACCEPTED", tx);
   });
 
-  return OrgRepository.getOrgById(invitation.orgId);
+  const org = await OrgRepository.getOrgById(invitation.orgId);
+  return org!;
 };
 
 const cancelInvitation = async (invitationId: string, orgId: string, requesterId: string) => {
@@ -113,6 +124,11 @@ const getProfileById = async (userId: string) => {
   return await OrgRepository.getProfileById(userId);
 };
 
+const getPendingInvitations = async (orgId: string, requesterId: string) => {
+  await assertOrgMember(requesterId, orgId);
+  return await OrgRepository.getPendingInvitationsByOrg(orgId);
+};
+
 const OrgService = {
   createOrg,
   getOrgById,
@@ -126,6 +142,7 @@ const OrgService = {
   cancelInvitation,
   removeMember,
   getProfileById,
+  getPendingInvitations,
 };
 
 export default OrgService;

--- a/apps/assassin/src/features/org/service.ts
+++ b/apps/assassin/src/features/org/service.ts
@@ -118,6 +118,13 @@ const removeMember = async (orgId: string, targetUserId: string, requesterId: st
   await OrgRepository.removeMember(orgId, targetUserId);
 };
 
+const leaveOrg = async (orgId: string, userId: string) => {
+  const member = await OrgRepository.getMember(orgId, userId);
+  if (!member) throw new Error("조직의 멤버가 아닙니다.");
+  if (member.role === "OWNER") throw new Error("OWNER는 조직을 나갈 수 없습니다.");
+  await OrgRepository.removeMember(orgId, userId);
+};
+
 const markInvitationEmailSent = async (invitationId: string) => {
   await OrgRepository.markInvitationEmailSent(invitationId);
 };
@@ -143,6 +150,7 @@ const OrgService = {
   acceptInvitation,
   cancelInvitation,
   removeMember,
+  leaveOrg,
   markInvitationEmailSent,
   getProfileById,
   getPendingInvitations,

--- a/apps/assassin/src/libs/supabase/middleware.ts
+++ b/apps/assassin/src/libs/supabase/middleware.ts
@@ -31,8 +31,9 @@ export const updateSession = async (request: NextRequest) => {
 
   const { pathname } = request.nextUrl;
   const isAuthPage = pathname === "/login" || pathname === "/signup";
+  const isPublicPage = isAuthPage || pathname.startsWith("/invite/accept");
 
-  if (!user && !isAuthPage) {
+  if (!user && !isPublicPage) {
     const url = request.nextUrl.clone();
     url.pathname = "/login";
     return NextResponse.redirect(url);

--- a/apps/assassin/supabase/migrations/20260407000000_org_invite_constraints_and_rls.sql
+++ b/apps/assassin/supabase/migrations/20260407000000_org_invite_constraints_and_rls.sql
@@ -91,9 +91,9 @@ CREATE POLICY "Org owners can delete org"
 ALTER TABLE public.org_member ENABLE ROW LEVEL SECURITY;
 
 DROP POLICY IF EXISTS "Org members can view members"    ON public.org_member;
-DROP POLICY IF EXISTS "Org admins can add members"      ON public.org_member;
+DROP POLICY IF EXISTS "Org owners can add members"      ON public.org_member;
 DROP POLICY IF EXISTS "Org owners can update roles"     ON public.org_member;
-DROP POLICY IF EXISTS "Org admins can remove members"   ON public.org_member;
+DROP POLICY IF EXISTS "Org owners can remove members"   ON public.org_member;
 
 -- 같은 org 멤버라면 멤버 목록 조회 가능
 CREATE POLICY "Org members can view members"
@@ -106,8 +106,8 @@ CREATE POLICY "Org members can view members"
     )
   );
 
--- ADMIN 이상만 멤버 추가 가능
-CREATE POLICY "Org admins can add members"
+-- OWNER 이상만 멤버 추가 가능
+CREATE POLICY "Org owners can add members"
   ON public.org_member FOR INSERT
   WITH CHECK (
     EXISTS (
@@ -130,8 +130,8 @@ CREATE POLICY "Org owners can update roles"
     )
   );
 
--- ADMIN 이상은 멤버 제거 가능, 또는 본인 스스로 탈퇴
-CREATE POLICY "Org admins can remove members"
+-- OWNER 이상은 멤버 제거 가능, 또는 본인 스스로 탈퇴
+CREATE POLICY "Org owners can remove members"
   ON public.org_member FOR DELETE
   USING (
     org_member."userId" = auth.uid()  -- 본인 탈퇴
@@ -149,14 +149,14 @@ CREATE POLICY "Org admins can remove members"
 
 ALTER TABLE public.org_invitation ENABLE ROW LEVEL SECURITY;
 
-DROP POLICY IF EXISTS "Org admins can view invitations"     ON public.org_invitation;
+DROP POLICY IF EXISTS "Org owners can view invitations"     ON public.org_invitation;
 DROP POLICY IF EXISTS "Invited user can view own invitation" ON public.org_invitation;
-DROP POLICY IF EXISTS "Org admins can create invitations"   ON public.org_invitation;
-DROP POLICY IF EXISTS "Org admins can cancel invitations"   ON public.org_invitation;
+DROP POLICY IF EXISTS "Org owners can create invitations"   ON public.org_invitation;
+DROP POLICY IF EXISTS "Org owners can cancel invitations"   ON public.org_invitation;
 DROP POLICY IF EXISTS "Invited user can accept invitation"  ON public.org_invitation;
 
--- ADMIN 이상은 해당 org의 초대 목록 조회 가능
-CREATE POLICY "Org admins can view invitations"
+-- OWNER 이상은 해당 org의 초대 목록 조회 가능
+CREATE POLICY "Org owners can view invitations"
   ON public.org_invitation FOR SELECT
   USING (
     EXISTS (
@@ -174,8 +174,8 @@ CREATE POLICY "Invited user can view own invitation"
     email = (SELECT email FROM auth.users WHERE id = auth.uid())
   );
 
--- ADMIN 이상만 초대 생성 가능
-CREATE POLICY "Org admins can create invitations"
+-- OWNER 이상만 초대 생성 가능
+CREATE POLICY "Org owners can create invitations"
   ON public.org_invitation FOR INSERT
   WITH CHECK (
     EXISTS (
@@ -186,8 +186,8 @@ CREATE POLICY "Org admins can create invitations"
     )
   );
 
--- ADMIN 이상은 초대 취소(status 업데이트) 가능
-CREATE POLICY "Org admins can cancel invitations"
+-- OWNER 이상은 초대 취소(status 업데이트) 가능
+CREATE POLICY "Org owners can cancel invitations"
   ON public.org_invitation FOR UPDATE
   USING (
     EXISTS (

--- a/apps/assassin/supabase/migrations/20260408000000_add_email_sent_at_to_org_invitation.sql
+++ b/apps/assassin/supabase/migrations/20260408000000_add_email_sent_at_to_org_invitation.sql
@@ -1,0 +1,1 @@
+ALTER TABLE org_invitation ADD COLUMN "emailSentAt" TIMESTAMPTZ;


### PR DESCRIPTION
## Summary                             
                                                                                         
  - 조직 초대 이메일 발송 기능 구현 (Resend)                                             
  - 이메일 발송 실패 시 재발송 가능한 복구 플로우 구현
  - 초대 수락 흐름 버그 수정 및 예외 처리 강화                                           
                                                                                         
  ## 주요 변경사항                                                                       
                                                                                         
  ### 초대 이메일 발송                                                               
  - Resend를 통한 조직 초대 이메일 발송 구현
  - 이메일 발송 성공 여부를 `emailSentAt` 컬럼으로 DB에 영속화                           
  - 미발송 초대와 발송 완료 초대를 UI에서 시각적으로 구분                                
                                                                                         
  ### 이메일 재발송 플로우                                                               
  - 발송 실패 시 `emailSent: false` 반환, UI에 경고 표시                                 
  - 대기 중인 초대 목록에 "이메일 발송 / 재발송" 버튼 제공                               
  - 재발송 시 기존 토큰 즉시 무효화 + 새 토큰 발급 (트랜잭션 보장)                       
                                                                                         
  ### 버그 수정                                                                          
  - `acceptInvitation`에서 `addMember` 이중 호출 → unique constraint 에러 수정           
  - 초대 수락 페이지의 login redirect `next` 파라미터 URL 인코딩 누락 수정 (토큰 소실)   
  - 미등록 사용자 초대 수락 플로우: 회원가입 후 `next`로 리다이렉트되지 않는 문제 수정   
  - `repository.ts`의 `Prisma` import 경로를 generated 경로로 수정 (빌드 에러)           
                                                                                         
  ### 기타                                                                               
  - `getPendingInvitations`에서 만료된 초대 필터링                                       
  - invite 관련 서비스 로직에 트랜잭션 적용  