### PR TITLE
`test(ymm): 핵심 모듈 단위 테스트 추가`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@
 
 # omc
 .omc
+
+# poor-dev runtime context
+.poor-dev-context.json

--- a/apps/ymm/src/discord/agentStore.ts
+++ b/apps/ymm/src/discord/agentStore.ts
@@ -1,4 +1,4 @@
-export type AgentType = 'claude' | 'codex'
+export type AgentType = 'claude' | 'codex' | 'poor-dev'
 
 const channelAgents = new Map<string, AgentType>()
 

--- a/apps/ymm/src/discord/bot.ts
+++ b/apps/ymm/src/discord/bot.ts
@@ -1,11 +1,21 @@
 import { Client, GatewayIntentBits, Message, TextChannel } from 'discord.js'
 import { execSync } from 'child_process'
-import { DISCORD_TOKEN, PROJECT_ROOT, DISCORD_COMMAND_ID, DISCORD_RESULT_ID, DISCORD_LOG_ID } from '../config.js'
+import {
+  DISCORD_TOKEN,
+  PROJECT_ROOT,
+  DISCORD_COMMAND_ID,
+  DISCORD_RESULT_ID,
+  DISCORD_LOG_ID,
+  GITHUB_REPO,
+  GITHUB_TOKEN,
+} from '../config.js'
 import { downloadAttachments, buildPrompt, cleanup } from './attachments.js'
 import { getSession, setSession, clearSession } from './sessionStore.js'
 import { killProcess, getProcess, setProcess, clearProcess } from './processStore.js'
 import { runClaudeCode } from '../claude/runner.js'
 import { runCodexCode } from '../codex/runner.js'
+import { runPoorDev } from '../poorDev/runner.js'
+import { clearPhase, getPhase } from '../poorDev/stateStore.js'
 import { fetchIssue, buildIssuePrompt, createPR } from '../github/client.js'
 import { splitIntoChunks } from '../utils/ansi.js'
 import { getAgent, setAgent } from './agentStore.js'
@@ -14,7 +24,7 @@ const COMMANDS = [
   { name: '!done',         desc: '현재 세션 종료 (다음 메시지부터 새 작업으로 시작)' },
   { name: '!stop',         desc: '실행 중인 작업 강제 종료 + 세션 초기화' },
   { name: '!session',      desc: '현재 활성 세션 ID 확인' },
-  { name: '!agent',        desc: '현재 에이전트 확인 또는 변경 (!agent claude | !agent codex)' },
+  { name: '!agent',        desc: '현재 에이전트 확인 또는 변경 (!agent claude | !agent codex | !agent poor-dev)' },
   { name: '!cost',         desc: 'Claude Code 세션의 토큰 사용량 확인' },
   { name: '#숫자',         desc: 'GitHub 이슈 번호로 Claude Code 작업 시작 (예: #42)' },
   { name: 'team N:작업',  desc: 'N개 워커로 멀티 에이전트 병렬 실행 (예: team 3:버튼 컴포넌트 리팩터)' },
@@ -55,8 +65,18 @@ client.on('messageCreate', async (message: Message) => {
 
   // !stop — 실행 중인 Claude 프로세스 강제 종료 + 세션 초기화
   if (text === '!stop') {
+    const phase = getPhase(message.channelId)
     const killed = killProcess(message.channelId)
     clearSession(message.channelId)
+    clearPhase(message.channelId)
+    if (phase.phase === 'coding') {
+      await message.reply(
+        killed
+          ? `🛑 작업을 중단했습니다. 브랜치 \`${phase.branchName}\` 에서 이어서 작업할 수 있습니다.`
+          : `ℹ️ 실행 중인 프로세스는 없지만, 브랜치 \`${phase.branchName}\` 에서 이어서 작업할 수 있습니다.`,
+      )
+      return
+    }
     await message.reply(killed
       ? '🛑 실행 중인 작업을 중단했습니다. 세션도 초기화되었습니다.'
       : '실행 중인 작업이 없습니다.')
@@ -66,6 +86,7 @@ client.on('messageCreate', async (message: Message) => {
   // !done — 현재 채널의 세션 종료
   if (text === '!done') {
     clearSession(message.channelId)
+    clearPhase(message.channelId)
     await message.reply('🔄 세션이 초기화되었습니다. 다음 메시지부터 새 작업으로 시작합니다.')
     return
   }
@@ -78,12 +99,21 @@ client.on('messageCreate', async (message: Message) => {
   }
 
   // !agent — 현재 에이전트 확인 / 변경
-  if (text === '!agent' || text === '!agent claude' || text === '!agent codex') {
+  if (text === '!agent' || text.startsWith('!agent ')) {
     if (text === '!agent') {
       await message.reply(`현재 에이전트: **${getAgent(message.channelId)}**`)
       return
     }
-    const nextAgent = text.endsWith('codex') ? 'codex' : 'claude'
+    const next = text.replace('!agent', '').trim().toLowerCase()
+    if (!['claude', 'codex', 'poor-dev'].includes(next)) {
+      await message.reply('사용법: `!agent claude` | `!agent codex` | `!agent poor-dev`')
+      return
+    }
+    if (next === 'poor-dev' && (!GITHUB_REPO || !GITHUB_TOKEN)) {
+      await message.reply('❌ `poor-dev` 모드는 `GITHUB_REPO`와 `GITHUB_TOKEN` 설정이 필요합니다.')
+      return
+    }
+    const nextAgent = next as 'claude' | 'codex' | 'poor-dev'
     setAgent(message.channelId, nextAgent)
     await message.reply(`✅ 현재 채널 에이전트가 **${nextAgent}** 로 변경되었습니다.`)
     return
@@ -198,18 +228,21 @@ client.on('messageCreate', async (message: Message) => {
   if (!text && !hasAttachments) return
 
   const agent = getAgent(message.channelId)
-  const processingMsg = await message.reply(
-    agent === 'claude' ? '⏳ Claude Code가 작업 중입니다...' : '⏳ Codex가 작업 중입니다...',
-  )
-
   const sessionId = getSession(message.channelId)
 
   const tempFiles: string[] = []
   try {
     const attachmentPaths = await downloadAttachments(message, tempFiles)
     const prompt = buildPrompt(text, attachmentPaths)
+    const processingMsg = agent === 'poor-dev'
+      ? null
+      : await message.reply(
+          agent === 'claude'
+            ? '⏳ Claude Code가 작업 중입니다...'
+            : '⏳ Codex가 작업 중입니다...',
+        )
     const child = agent === 'claude'
-      ? runClaudeCode(prompt, message, processingMsg, tempFiles, {
+      ? runClaudeCode(prompt, message, processingMsg!, tempFiles, {
           sessionId,
           onSessionId: (id) => setSession(message.channelId, id),
           onDone: () => clearProcess(message.channelId),
@@ -217,29 +250,40 @@ client.on('messageCreate', async (message: Message) => {
           resultChannel: getTextChannel(DISCORD_RESULT_ID),
           commandChannel: getTextChannel(DISCORD_COMMAND_ID),
         })
-      : runCodexCode(prompt, message, processingMsg, tempFiles, {
-          onDone: () => clearProcess(message.channelId),
-          logChannel: getTextChannel(DISCORD_LOG_ID),
-          resultChannel: getTextChannel(DISCORD_RESULT_ID),
-          commandChannel: getTextChannel(DISCORD_COMMAND_ID),
-          onApprovalRequest: (_approvalPrompt) => {
-            const ch = getTextChannel(DISCORD_COMMAND_ID) ?? (message.channel as TextChannel)
-            return new Promise((resolve) => {
-              const collector = ch.createMessageCollector({
-                filter: (m: Message) => !m.author.bot && /^[yn]$/i.test(m.content.trim()),
-                max: 1,
-                time: 60_000,
+      : agent === 'codex'
+        ? runCodexCode(prompt, message, processingMsg!, tempFiles, {
+            onDone: () => clearProcess(message.channelId),
+            logChannel: getTextChannel(DISCORD_LOG_ID),
+            resultChannel: getTextChannel(DISCORD_RESULT_ID),
+            commandChannel: getTextChannel(DISCORD_COMMAND_ID),
+            onApprovalRequest: (_approvalPrompt) => {
+              const ch = getTextChannel(DISCORD_COMMAND_ID) ?? (message.channel as TextChannel)
+              return new Promise((resolve) => {
+                const collector = ch.createMessageCollector({
+                  filter: (m: Message) => !m.author.bot && /^[yn]$/i.test(m.content.trim()),
+                  max: 1,
+                  time: 60_000,
+                })
+                collector.on('collect', (m: Message) => resolve(m.content.trim()))
+                collector.on('end', (_collected: unknown, reason: string) => {
+                  if (reason === 'time') resolve('n')
+                })
               })
-              collector.on('collect', (m: Message) => resolve(m.content.trim()))
-              collector.on('end', (_collected: unknown, reason: string) => {
-                if (reason === 'time') resolve('n')
-              })
-            })
-          },
-        })
-    setProcess(message.channelId, child)
+            },
+          })
+        : await runPoorDev(prompt, message, {
+            logChannel: getTextChannel(DISCORD_LOG_ID),
+            resultChannel: getTextChannel(DISCORD_RESULT_ID),
+            commandChannel: getTextChannel(DISCORD_COMMAND_ID),
+          }, {
+            tempFiles,
+            onDone: () => clearProcess(message.channelId),
+            onProcessSwitch: (nextChild) => setProcess(message.channelId, nextChild),
+          })
+    if (child) setProcess(message.channelId, child)
+    else await cleanup(tempFiles)
   } catch (err) {
-    await processingMsg.edit(`❌ 첨부파일 다운로드 실패: ${(err as Error).message}`)
+    await message.reply(`❌ 작업 시작 실패: ${(err as Error).message}`)
     await cleanup(tempFiles)
   }
 })

--- a/apps/ymm/src/discord/bot.ts
+++ b/apps/ymm/src/discord/bot.ts
@@ -16,6 +16,7 @@ import { runClaudeCode } from '../claude/runner.js'
 import { runCodexCode } from '../codex/runner.js'
 import { runPoorDev } from '../poorDev/runner.js'
 import { clearPhase, getPhase } from '../poorDev/stateStore.js'
+import { clearContext } from '../poorDev/contextStore.js'
 import { fetchIssue, buildIssuePrompt, createPR } from '../github/client.js'
 import { splitIntoChunks } from '../utils/ansi.js'
 import { getAgent, setAgent } from './agentStore.js'
@@ -69,6 +70,7 @@ client.on('messageCreate', async (message: Message) => {
     const killed = killProcess(message.channelId)
     clearSession(message.channelId)
     clearPhase(message.channelId)
+    clearContext(message.channelId)
     if (phase.phase === 'coding') {
       await message.reply(
         killed
@@ -87,6 +89,7 @@ client.on('messageCreate', async (message: Message) => {
   if (text === '!done') {
     clearSession(message.channelId)
     clearPhase(message.channelId)
+    clearContext(message.channelId)
     await message.reply('🔄 세션이 초기화되었습니다. 다음 메시지부터 새 작업으로 시작합니다.')
     return
   }

--- a/apps/ymm/src/github/client.ts
+++ b/apps/ymm/src/github/client.ts
@@ -14,6 +14,47 @@ export interface GitHubPR {
   url: string
 }
 
+export async function createIssue(
+  title: string,
+  body: string,
+  labels: string[] = [],
+): Promise<number> {
+  if (!GITHUB_TOKEN || !GITHUB_REPO) {
+    throw new Error('GITHUB_TOKEN 또는 GITHUB_REPO가 설정되지 않았습니다.')
+  }
+
+  const create = async (withLabels: boolean) => {
+    const res = await fetch(`https://api.github.com/repos/${GITHUB_REPO}/issues`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${GITHUB_TOKEN}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        title,
+        body,
+        ...(withLabels ? { labels } : {}),
+      }),
+    })
+    return res
+  }
+
+  let res = await create(labels.length > 0)
+  if (!res.ok && labels.length > 0 && res.status === 422) {
+    res = await create(false)
+  }
+
+  if (!res.ok) {
+    const errorBody = await res.text()
+    throw new Error(`이슈 생성 실패: ${res.status} ${res.statusText} - ${errorBody}`)
+  }
+
+  const data = await res.json() as { number: number }
+  return data.number
+}
+
 export async function fetchIssue(issueNumber: number): Promise<GitHubIssue> {
   if (!GITHUB_TOKEN || !GITHUB_REPO) {
     throw new Error('GITHUB_TOKEN 또는 GITHUB_REPO가 설정되지 않았습니다.')
@@ -49,12 +90,19 @@ export async function fetchIssue(issueNumber: number): Promise<GitHubIssue> {
   }
 }
 
-export async function createPR(issue: GitHubIssue, branchName: string, baseBranch = 'dev'): Promise<GitHubPR> {
+export async function createPR(
+  issue: GitHubIssue,
+  branchName: string,
+  baseBranch = 'dev',
+  bodyOverride?: string,
+  titleOverride?: string,
+): Promise<GitHubPR> {
   if (!GITHUB_TOKEN || !GITHUB_REPO) {
     throw new Error('GITHUB_TOKEN 또는 GITHUB_REPO가 설정되지 않았습니다.')
   }
 
-  const body = [`closes #${issue.number}`, '', issue.body ?? ''].join('\n').trim()
+  const body = bodyOverride ?? [`closes #${issue.number}`, '', issue.body ?? ''].join('\n').trim()
+  const title = titleOverride ?? issue.title
 
   const res = await fetch(`https://api.github.com/repos/${GITHUB_REPO}/pulls`, {
     method: 'POST',
@@ -65,7 +113,7 @@ export async function createPR(issue: GitHubIssue, branchName: string, baseBranc
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      title: issue.title,
+      title,
       body,
       head: branchName,
       base: baseBranch,

--- a/apps/ymm/src/poorDev/codingPhase.ts
+++ b/apps/ymm/src/poorDev/codingPhase.ts
@@ -1,14 +1,17 @@
 import { Message } from 'discord.js'
 import { ChildProcess, spawn } from 'child_process'
 import readline from 'node:readline'
-import { CODEX_BIN, PROJECT_ROOT } from '../config.js'
+import { PROJECT_ROOT } from '../config.js'
 import { truncate } from '../utils/ansi.js'
 import { filterCodingLine, resetCodingLogFilterState } from './logFilter.js'
+import { buildSharedAgentContextPrompt } from '../sharedAgentContext.js'
 
 type SendFn = (content: string) => Promise<unknown>
 
 type RunCodingOptions = {
   logChannel?: { send: SendFn }
+  sessionId?: string
+  onSessionId?: (id: string) => void
   onWorkLogEntry?: (line: string) => void
   onDone?: () => void
   onClose?: (code: number | null) => Promise<void> | void
@@ -25,7 +28,14 @@ function buildCodexPrompt(issueNumber: number, designDoc: string, originalPrompt
     '[설계 문서]',
     designDoc,
     '',
-    '위 요청과 설계를 기준으로 구현을 완료하세요. 테스트/빌드 확인까지 수행하고 최종 요약을 남기세요.',
+    '[작업 규칙]',
+    '1. 반드시 설계 문서의 구현 계획 순서를 따르세요.',
+    '2. 각 단계를 완료할 때마다 관련 파일만 선별 stage 후 커밋하세요.',
+    '3. 커밋 메시지는 feat(<scope>): <설명> 형식을 사용하세요.',
+    '4. 영향 범위 밖의 파일은 수정하지 마세요.',
+    '5. 테스트/빌드 검증 후 완료 조건을 하나씩 체크하고 종료하세요.',
+    '',
+    '위 요청과 설계를 기준으로 구현을 완료하고, 최종 요약에는 단계별 변경/커밋/검증 결과를 포함하세요.',
   ].join('\n')
 }
 
@@ -34,30 +44,80 @@ export function runPoorDevCoding(
   designDoc: string,
   originalPrompt: string,
   processingMsg: Message,
-  { logChannel, onWorkLogEntry, onDone, onClose, onError }: RunCodingOptions,
+  { logChannel, sessionId, onSessionId, onWorkLogEntry, onDone, onClose, onError }: RunCodingOptions,
 ): ChildProcess {
-  const prompt = buildCodexPrompt(issueNumber, designDoc, originalPrompt)
+  const prompt = `${buildSharedAgentContextPrompt({ projectRoot: PROJECT_ROOT })}\n${buildCodexPrompt(issueNumber, designDoc, originalPrompt)}`
   resetCodingLogFilterState()
 
-  const child = spawn(
-    CODEX_BIN,
-    ['exec', '--dangerously-bypass-approvals-and-sandbox', prompt],
-    {
-      cwd: PROJECT_ROOT,
-      env: { ...process.env },
-      stdio: ['ignore', 'pipe', 'pipe'],
-    },
-  )
+  const args = sessionId
+    ? ['--resume', sessionId, '-p', prompt]
+    : ['-p', prompt]
+  args.push('--allowedTools', 'Read,Write,Edit,Bash,Glob,Grep', '--output-format', 'stream-json', '--verbose')
+
+  const child = spawn('claude', args, {
+    cwd: PROJECT_ROOT,
+    env: { ...process.env },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  let resultCode: number | null = 1
 
   const rl = readline.createInterface({ input: child.stdout, crlfDelay: Infinity })
   rl.on('line', (line) => {
-    const raw = line.replace(/\r/g, '')
+    if (!line.trim()) return
+    let event: Record<string, unknown>
+    try {
+      event = JSON.parse(line)
+    } catch {
+      return
+    }
 
-    const filtered = filterCodingLine(raw)
-    if (!filtered.emit || !filtered.text) return
+    if (event.type === 'system') {
+      const sid = (event as { session_id?: unknown }).session_id
+      if (typeof sid === 'string' && sid.trim()) onSessionId?.(sid.trim())
+      return
+    }
 
-    logChannel?.send(`🧠 [poor-dev/coding] ${truncate(filtered.text, 250)}`).catch(() => {})
-    onWorkLogEntry?.(filtered.text)
+    if (event.type === 'assistant') {
+      type ContentBlock = { type: string; text?: string; thinking?: string }
+      const content: ContentBlock[] = (event.message as { content?: ContentBlock[] })?.content ?? []
+      const text = content
+        .filter((b) => b.type === 'text' || b.type === 'thinking')
+        .map((b) => b.text ?? b.thinking ?? '')
+        .join('\n')
+        .trim()
+      if (!text) return
+
+      const lines = text.split(/\r?\n/).map((entry) => entry.trim()).filter(Boolean)
+      for (const raw of lines) {
+        const filtered = filterCodingLine(raw)
+        if (!filtered.emit || !filtered.text) continue
+        const safe = truncate(filtered.text, 250)
+        logChannel?.send(`🧠 [poor-dev/coding] ${safe}`).catch(() => {})
+        onWorkLogEntry?.(safe)
+      }
+      return
+    }
+
+    if (event.type === 'result') {
+      const result = event as { subtype?: string; result?: unknown }
+      if (result.subtype === 'success') {
+        resultCode = 0
+        const summary = typeof result.result === 'string'
+          ? result.result
+          : JSON.stringify(result.result ?? '', null, 2)
+        const lines = summary.split(/\r?\n/).map((entry) => entry.trim()).filter(Boolean)
+        for (const raw of lines) {
+          const filtered = filterCodingLine(raw)
+          if (!filtered.emit || !filtered.text) continue
+          const safe = truncate(filtered.text, 250)
+          logChannel?.send(`🧠 [poor-dev/coding] ${safe}`).catch(() => {})
+          onWorkLogEntry?.(safe)
+        }
+      } else {
+        resultCode = 1
+      }
+    }
   })
 
   child.stderr.on('data', (chunk: Buffer) => {
@@ -74,17 +134,20 @@ export function runPoorDevCoding(
 
   child.on('close', async (code) => {
     onDone?.()
-    if (code === 0) {
+    const finalCode = code === 0
+      ? (resultCode ?? 1)
+      : (code ?? resultCode ?? 1)
+    if (finalCode === 0) {
       await processingMsg.edit('✅ poor-dev 코딩 단계가 완료되었습니다.').catch(() => {})
     } else {
-      await processingMsg.edit(`❌ poor-dev 코딩 단계 실패 (code=${code ?? 'null'})`).catch(() => {})
+      await processingMsg.edit(`❌ poor-dev 코딩 단계 실패 (code=${finalCode ?? 'null'})`).catch(() => {})
     }
-    await onClose?.(code)
+    await onClose?.(finalCode)
   })
 
   child.on('error', async (err) => {
     const msg = err.message.includes('ENOENT')
-      ? `'${CODEX_BIN}' 명령어를 찾을 수 없습니다. Codex CLI 설치를 확인하세요.`
+      ? "'claude' 명령어를 찾을 수 없습니다. Claude Code CLI 설치를 확인하세요."
       : err.message
     await processingMsg.edit(`❌ ${msg}`).catch(() => {})
     await onError?.(new Error(msg))

--- a/apps/ymm/src/poorDev/codingPhase.ts
+++ b/apps/ymm/src/poorDev/codingPhase.ts
@@ -1,0 +1,95 @@
+import { Message } from 'discord.js'
+import { ChildProcess, spawn } from 'child_process'
+import readline from 'node:readline'
+import { CODEX_BIN, PROJECT_ROOT } from '../config.js'
+import { truncate } from '../utils/ansi.js'
+import { filterCodingLine, resetCodingLogFilterState } from './logFilter.js'
+
+type SendFn = (content: string) => Promise<unknown>
+
+type RunCodingOptions = {
+  logChannel?: { send: SendFn }
+  onWorkLogEntry?: (line: string) => void
+  onDone?: () => void
+  onClose?: (code: number | null) => Promise<void> | void
+  onError?: (err: Error) => Promise<void> | void
+}
+
+function buildCodexPrompt(issueNumber: number, designDoc: string, originalPrompt: string): string {
+  return [
+    `GitHub Issue #${issueNumber}`,
+    '',
+    '[원본 요청]',
+    originalPrompt,
+    '',
+    '[설계 문서]',
+    designDoc,
+    '',
+    '위 요청과 설계를 기준으로 구현을 완료하세요. 테스트/빌드 확인까지 수행하고 최종 요약을 남기세요.',
+  ].join('\n')
+}
+
+export function runPoorDevCoding(
+  issueNumber: number,
+  designDoc: string,
+  originalPrompt: string,
+  processingMsg: Message,
+  { logChannel, onWorkLogEntry, onDone, onClose, onError }: RunCodingOptions,
+): ChildProcess {
+  const prompt = buildCodexPrompt(issueNumber, designDoc, originalPrompt)
+  resetCodingLogFilterState()
+
+  const child = spawn(
+    CODEX_BIN,
+    ['exec', '--dangerously-bypass-approvals-and-sandbox', prompt],
+    {
+      cwd: PROJECT_ROOT,
+      env: { ...process.env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  )
+
+  const rl = readline.createInterface({ input: child.stdout, crlfDelay: Infinity })
+  rl.on('line', (line) => {
+    const raw = line.replace(/\r/g, '')
+
+    const filtered = filterCodingLine(raw)
+    if (!filtered.emit || !filtered.text) return
+
+    logChannel?.send(`🧠 [poor-dev/coding] ${truncate(filtered.text, 250)}`).catch(() => {})
+    onWorkLogEntry?.(filtered.text)
+  })
+
+  child.stderr.on('data', (chunk: Buffer) => {
+    const text = chunk.toString()
+    const lines = text.split(/\r?\n/).map((line) => line.trim()).filter(Boolean)
+    for (const line of lines) {
+      const filtered = filterCodingLine(line)
+      if (!filtered.emit || !filtered.text) continue
+      const safe = truncate(filtered.text, 300)
+      logChannel?.send(`⚠️ [poor-dev/coding stderr] ${safe}`).catch(() => {})
+      onWorkLogEntry?.(`오류: ${safe}`)
+    }
+  })
+
+  child.on('close', async (code) => {
+    onDone?.()
+    if (code === 0) {
+      await processingMsg.edit('✅ poor-dev 코딩 단계가 완료되었습니다.').catch(() => {})
+    } else {
+      await processingMsg.edit(`❌ poor-dev 코딩 단계 실패 (code=${code ?? 'null'})`).catch(() => {})
+    }
+    await onClose?.(code)
+  })
+
+  child.on('error', async (err) => {
+    const msg = err.message.includes('ENOENT')
+      ? `'${CODEX_BIN}' 명령어를 찾을 수 없습니다. Codex CLI 설치를 확인하세요.`
+      : err.message
+    await processingMsg.edit(`❌ ${msg}`).catch(() => {})
+    await onError?.(new Error(msg))
+    onDone?.()
+  })
+
+  return child
+}

--- a/apps/ymm/src/poorDev/contextStore.ts
+++ b/apps/ymm/src/poorDev/contextStore.ts
@@ -1,0 +1,67 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { PROJECT_ROOT } from '../config.js'
+
+const MAX_DESIGN_DOC_LENGTH = 60000
+const CONTEXT_FILE = '.poor-dev-context.json'
+const CONTEXT_PATH = path.join(PROJECT_ROOT, CONTEXT_FILE)
+
+export type PoorDevContext = {
+  channelId: string
+  originalPrompt: string
+  designDoc: string
+  issueNumber: number
+  branchName: string
+  designSessionId?: string
+  startedAt: string
+}
+
+export function saveContext(context: PoorDevContext): void {
+  try {
+    const safeContext: PoorDevContext = {
+      ...context,
+      designDoc: context.designDoc.slice(0, MAX_DESIGN_DOC_LENGTH),
+    }
+    fs.writeFileSync(CONTEXT_PATH, JSON.stringify(safeContext, null, 2), 'utf8')
+  } catch {
+    // 런타임 컨텍스트 저장 실패는 전체 파이프라인 실패로 취급하지 않는다.
+  }
+}
+
+export function loadContext(): PoorDevContext | null {
+  if (!fs.existsSync(CONTEXT_PATH)) return null
+  try {
+    const parsed = JSON.parse(fs.readFileSync(CONTEXT_PATH, 'utf8')) as Partial<PoorDevContext>
+    if (!parsed || typeof parsed !== 'object') return null
+    if (typeof parsed.channelId !== 'string') return null
+    if (typeof parsed.originalPrompt !== 'string') return null
+    if (typeof parsed.designDoc !== 'string') return null
+    if (typeof parsed.issueNumber !== 'number') return null
+    if (typeof parsed.branchName !== 'string') return null
+    if (typeof parsed.startedAt !== 'string') return null
+    return {
+      channelId: parsed.channelId,
+      originalPrompt: parsed.originalPrompt,
+      designDoc: parsed.designDoc.slice(0, MAX_DESIGN_DOC_LENGTH),
+      issueNumber: parsed.issueNumber,
+      branchName: parsed.branchName,
+      designSessionId: typeof parsed.designSessionId === 'string' ? parsed.designSessionId : undefined,
+      startedAt: parsed.startedAt,
+    }
+  } catch {
+    return null
+  }
+}
+
+export function clearContext(channelId?: string): void {
+  if (!fs.existsSync(CONTEXT_PATH)) return
+  try {
+    if (channelId) {
+      const existing = loadContext()
+      if (existing && existing.channelId !== channelId) return
+    }
+    fs.unlinkSync(CONTEXT_PATH)
+  } catch {
+    // 컨텍스트 정리 실패는 호출자 흐름을 중단하지 않는다.
+  }
+}

--- a/apps/ymm/src/poorDev/designPhase.ts
+++ b/apps/ymm/src/poorDev/designPhase.ts
@@ -1,0 +1,171 @@
+import { Message } from 'discord.js'
+import { ChildProcess, spawn } from 'child_process'
+import readline from 'node:readline'
+import { PROJECT_ROOT } from '../config.js'
+import { truncate } from '../utils/ansi.js'
+
+type SendFn = (content: string) => Promise<unknown>
+
+type RunDesignOptions = {
+  logChannel?: { send: SendFn }
+  onDesignComplete: (designDoc: string) => Promise<void> | void
+  onDone?: () => void
+  onError?: (err: Error) => Promise<void> | void
+}
+
+const DESIGN_PROMPT_HEADER = `당신은 구현자가 아니라 설계자입니다.
+코드 수정/실행/파일 변경 없이 Read/Glob/Grep/Bash(읽기 전용 조회)만 사용하세요.
+
+출력은 반드시 아래 섹션을 모두 포함하세요.
+## 목표
+## 영향 범위
+## 구현 계획
+## 완료 조건
+## ISSUE_TITLE
+## ISSUE_LABEL
+
+제약:
+- ISSUE_TITLE은 70자 이내 한 줄
+- ISSUE_LABEL은 enhancement 또는 task 중 하나
+- 불필요한 서론/결론 없이 설계 문서만 출력
+`
+
+function sanitizeReasoningText(text: string): string {
+  const compact = text.replace(/\s+/g, ' ').trim()
+  if (!compact) return ''
+  if (/```/.test(compact)) return ''
+  if (/^(diff\s+--git|index\s+[a-f0-9]+|@@\s|\+\+\+\s|---\s)/.test(compact)) return ''
+  if (/^[+-].{20,}/.test(compact)) return ''
+  if (/(^|\s)(const|let|var|function|class|interface|type|import|export|return|if|for|while|switch|try|catch)\b/.test(compact)) return ''
+  if (/=>/.test(compact)) return ''
+  if (/^[a-zA-Z_$][\w$]*\s*\(.*\)\s*\{?$/.test(compact)) return ''
+  if (/[{}()[\];]/.test(compact) && /[=:]/.test(compact)) return ''
+  const noSpace = compact.replace(/\s/g, '')
+  const ratio = noSpace.length
+    ? ((noSpace.match(/[{}()[\];=<>`$\\]/g) ?? []).length / noSpace.length)
+    : 0
+  if (compact.length > 80 && ratio > 0.4) return ''
+  return compact
+}
+
+export function runPoorDevDesign(
+  prompt: string,
+  _message: Message,
+  processingMsg: Message,
+  { logChannel, onDesignComplete, onDone, onError }: RunDesignOptions,
+): ChildProcess {
+  const fullPrompt = `${DESIGN_PROMPT_HEADER}\n\n[요청]\n${prompt}`
+
+  const child = spawn('claude', [
+    '-p',
+    fullPrompt,
+    '--allowedTools',
+    'Read,Glob,Grep,Bash',
+    '--output-format',
+    'stream-json',
+    '--verbose',
+  ], {
+    cwd: PROJECT_ROOT,
+    env: { ...process.env },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  let done = false
+  let stderr = ''
+  let designDoc = ''
+  let fallback = ''
+
+  const finish = () => {
+    if (done) return
+    done = true
+    onDone?.()
+  }
+
+  const rl = readline.createInterface({ input: child.stdout, crlfDelay: Infinity })
+  rl.on('line', (line) => {
+    if (!line.trim()) return
+
+    let event: Record<string, unknown>
+    try {
+      event = JSON.parse(line)
+    } catch {
+      return
+    }
+
+    if (event.type === 'assistant') {
+      type ContentBlock = { type: string; text?: string; thinking?: string }
+      const content: ContentBlock[] = (event.message as { content?: ContentBlock[] })?.content ?? []
+      const reasoning = content
+        .filter((b) => b.type === 'text' || b.type === 'thinking')
+        .map((b) => b.text ?? b.thinking ?? '')
+        .join('')
+        .trim()
+      if (reasoning) {
+        fallback += reasoning + '\n'
+        const safe = sanitizeReasoningText(reasoning)
+        if (safe) {
+          const text = truncate(safe, 250)
+          logChannel?.send(`🧠 [poor-dev/design] ${text}`).catch(() => {})
+        }
+      }
+      return
+    }
+
+    if (event.type === 'result') {
+      const result = event as { subtype?: string; result?: unknown }
+      if (result.subtype === 'success') {
+        if (typeof result.result === 'string' && result.result.trim()) {
+          designDoc = result.result.trim()
+          return
+        }
+        if (result.result != null) {
+          const fallbackResult = typeof result.result === 'object'
+            ? JSON.stringify(result.result, null, 2)
+            : String(result.result)
+          if (fallbackResult.trim()) designDoc = fallbackResult.trim()
+        }
+      }
+    }
+  })
+
+  child.stderr.on('data', (chunk: Buffer) => {
+    const text = chunk.toString().trim()
+    if (!text) return
+    stderr += text + '\n'
+    logChannel?.send(`⚠️ [poor-dev/design stderr] ${truncate(text, 400)}`).catch(() => {})
+  })
+
+  child.on('close', async (code) => {
+    try {
+      if (code !== 0) {
+        const msg = stderr.trim() || `설계 단계 실패 (code=${code ?? 'null'})`
+        await processingMsg.edit(`❌ ${truncate(msg, 1800)}`).catch(() => {})
+        await onError?.(new Error(msg))
+        return
+      }
+
+      const finalDoc = (designDoc || fallback || '').trim()
+      if (!finalDoc) {
+        const msg = '설계 문서를 생성하지 못했습니다.'
+        await processingMsg.edit(`❌ ${msg}`).catch(() => {})
+        await onError?.(new Error(msg))
+        return
+      }
+
+      await onDesignComplete(finalDoc)
+    } finally {
+      finish()
+    }
+  })
+
+  child.on('error', async (err) => {
+    const msg = err.message.includes('ENOENT')
+      ? "'claude' 명령어를 찾을 수 없습니다. Claude CLI 설치를 확인하세요."
+      : err.message
+    await processingMsg.edit(`❌ ${msg}`).catch(() => {})
+    await onError?.(new Error(msg))
+    finish()
+  })
+
+  return child
+}

--- a/apps/ymm/src/poorDev/designPhase.ts
+++ b/apps/ymm/src/poorDev/designPhase.ts
@@ -8,7 +8,7 @@ type SendFn = (content: string) => Promise<unknown>
 
 type RunDesignOptions = {
   logChannel?: { send: SendFn }
-  onDesignComplete: (designDoc: string) => Promise<void> | void
+  onDesignComplete: (designDoc: string, sessionId?: string) => Promise<void> | void
   onDone?: () => void
   onError?: (err: Error) => Promise<void> | void
 }
@@ -74,6 +74,7 @@ export function runPoorDevDesign(
   let stderr = ''
   let designDoc = ''
   let fallback = ''
+  let designSessionId: string | undefined
 
   const finish = () => {
     if (done) return
@@ -89,6 +90,14 @@ export function runPoorDevDesign(
     try {
       event = JSON.parse(line)
     } catch {
+      return
+    }
+
+    if (event.type === 'system') {
+      const sid = (event as { session_id?: unknown }).session_id
+      if (typeof sid === 'string' && sid.trim()) {
+        designSessionId = sid.trim()
+      }
       return
     }
 
@@ -152,7 +161,7 @@ export function runPoorDevDesign(
         return
       }
 
-      await onDesignComplete(finalDoc)
+      await onDesignComplete(finalDoc, designSessionId)
     } finally {
       finish()
     }

--- a/apps/ymm/src/poorDev/logFilter.ts
+++ b/apps/ymm/src/poorDev/logFilter.ts
@@ -1,0 +1,86 @@
+function codeCharRatio(text: string): number {
+  const meaningful = text.replace(/\s/g, '')
+  if (!meaningful) return 0
+  const codeLike = (meaningful.match(/[{}()[\];=<>`$\\]/g) ?? []).length
+  return codeLike / meaningful.length
+}
+
+let inCodeBlock = false
+let previousBlank = false
+
+export function resetCodingLogFilterState(): void {
+  inCodeBlock = false
+  previousBlank = false
+}
+
+function hasSummaryKeyword(line: string): boolean {
+  return /(완료|수정|추가|제거|리팩터|테스트|빌드|검증|적용|updated|fixed|added|removed|refactor|test|build|implement|changed|created)/i.test(line)
+}
+
+function hasErrorKeyword(line: string): boolean {
+  return /(error|fail|failed|warning|exception|traceback|ENOENT|EACCES|EPERM|fatal)/i.test(line)
+}
+
+function isDiffMarker(line: string): boolean {
+  return /^(diff\s+--git|index\s+[a-f0-9]+|@@\s|@@$|\+\+\+\s|---\s)/.test(line)
+}
+
+function isDiffContent(line: string): boolean {
+  if (/^\+/.test(line)) return true
+  if (!/^-/.test(line)) return false
+
+  // markdown bullet summary는 허용하고, 코드/패치 라인만 차단
+  if (/^-\s+[\p{L}\p{N}]/u.test(line) && codeCharRatio(line) < 0.2) return false
+  return true
+}
+
+function isCodeLikeSentence(line: string): boolean {
+  return /(^|\s)(const|let|var|function|class|interface|type|import|export|return|if|for|while|switch|try|catch)\b/.test(line)
+}
+
+function isCodeSnippet(line: string): boolean {
+  if (isCodeLikeSentence(line)) return true
+  if (/=>/.test(line)) return true
+  if (/^[a-zA-Z_$][\w$]*\s*\(.*\)\s*\{?$/.test(line)) return true
+  if (/[{}()[\];]/.test(line) && /[=:]/.test(line)) return true
+  if (/^<\/?[A-Za-z][^>]*>$/.test(line)) return true
+  return false
+}
+
+export function filterCodingLine(line: string): { emit: boolean; text: string } {
+  const text = line.trim()
+
+  if (!text) {
+    if (previousBlank) return { emit: false, text: '' }
+    previousBlank = true
+    return { emit: false, text: '' }
+  }
+  previousBlank = false
+
+  if (/^```/.test(text)) {
+    inCodeBlock = !inCodeBlock
+    return { emit: false, text: '' }
+  }
+  if (inCodeBlock) return { emit: false, text: '' }
+  if (isDiffMarker(text)) return { emit: false, text }
+  if (isDiffContent(text)) return { emit: false, text }
+  if (isCodeSnippet(text)) return { emit: false, text }
+
+  const ratio = codeCharRatio(text)
+
+  // 에러/경고는 우선 전달하되, 너무 코드스러운 긴 라인은 차단
+  if (hasErrorKeyword(text)) {
+    if (text.length > 80 && ratio > 0.4) return { emit: false, text }
+    return { emit: true, text: text.slice(0, 200) }
+  }
+
+  if (text.length > 80 && isCodeLikeSentence(text) && ratio > 0.2) return { emit: false, text }
+  if (text.length > 80 && ratio > 0.4) return { emit: false, text }
+
+  if (text.length <= 60) return { emit: true, text }
+  if (hasSummaryKeyword(text) && ratio < 0.3) return { emit: true, text: text.slice(0, 200) }
+
+  if (text.length <= 200 && ratio < 0.3) return { emit: true, text }
+
+  return { emit: false, text }
+}

--- a/apps/ymm/src/poorDev/prSummary.ts
+++ b/apps/ymm/src/poorDev/prSummary.ts
@@ -1,0 +1,41 @@
+function section(doc: string, title: string): string {
+  const escaped = title.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const re = new RegExp(`^##\\s*${escaped}\\s*\\n([\\s\\S]*?)(?=^##\\s|$)`, 'im')
+  return (doc.match(re)?.[1] ?? '').trim()
+}
+
+export function buildPRBody(params: {
+  issueNumber: number
+  designDoc: string
+  workLog: string[]
+}): string {
+  const workItems = params.workLog
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .slice(0, 20)
+    .map((line) => `- ${line.slice(0, 200)}`)
+
+  const goal = section(params.designDoc, '목표')
+  const done = section(params.designDoc, '완료 조건') || section(params.designDoc, '완료조건')
+
+  const blocks = [
+    `closes #${params.issueNumber}`,
+    '',
+    '## 작업 내용',
+    ...(workItems.length > 0 ? workItems : ['- (로그 기반 요약 없음)']),
+    '',
+    '## 설계 기반',
+  ]
+
+  if (goal) {
+    blocks.push('### 목표', goal)
+  }
+  if (done) {
+    blocks.push('### 완료 조건', done)
+  }
+  if (!goal && !done) {
+    blocks.push(params.designDoc.slice(0, 2000))
+  }
+
+  return blocks.join('\n').trim()
+}

--- a/apps/ymm/src/poorDev/runner.ts
+++ b/apps/ymm/src/poorDev/runner.ts
@@ -1,4 +1,4 @@
-import { ChildProcess, execSync } from 'child_process'
+import { ChildProcess, execFileSync, execSync } from 'child_process'
 import { Message, TextChannel } from 'discord.js'
 import { GITHUB_REPO, GITHUB_TOKEN, PROJECT_ROOT } from '../config.js'
 import { cleanup } from '../discord/attachments.js'
@@ -7,6 +7,7 @@ import { buildPRBody } from './prSummary.js'
 import { getPhase, setPhase } from './stateStore.js'
 import { runPoorDevDesign } from './designPhase.js'
 import { runPoorDevCoding } from './codingPhase.js'
+import { clearContext, loadContext, saveContext } from './contextStore.js'
 
 type Channels = {
   logChannel?: TextChannel
@@ -62,6 +63,24 @@ function buildIssueBodyFromDesign(designDocRaw: string): string {
   return `${trimmed.slice(0, 60000)}\n\n(자동 잘림: designDoc 길이가 너무 길어 60,000자로 제한됨)`
 }
 
+function commitPendingChanges(issueNumber: number, logChannel?: TextChannel): void {
+  try {
+    const status = execFileSync('git', ['-C', PROJECT_ROOT, 'status', '--porcelain'], { encoding: 'utf8' }).trim()
+    if (!status) return
+
+    execFileSync('git', ['-C', PROJECT_ROOT, 'add', '-A'], { stdio: 'pipe' })
+
+    const staged = execFileSync('git', ['-C', PROJECT_ROOT, 'diff', '--cached', '--name-only'], { encoding: 'utf8' }).trim()
+    if (!staged) return
+
+    const commitMessage = `feat(poor-dev): implement issue #${issueNumber}\n\ncloses #${issueNumber}`
+    execFileSync('git', ['-C', PROJECT_ROOT, 'commit', '-m', commitMessage], { stdio: 'pipe' })
+    logChannel?.send('✅ [poor-dev] 미커밋 변경사항을 자동 커밋했습니다.').catch(() => {})
+  } catch (err) {
+    logChannel?.send(`⚠️ [poor-dev] 자동 커밋 실패(계속 진행): ${(err as Error).message}`).catch(() => {})
+  }
+}
+
 export async function runPoorDev(
   prompt: string,
   message: Message,
@@ -76,6 +95,10 @@ export async function runPoorDev(
   }
 
   const channelId = message.channelId
+  const existingContext = loadContext()
+  if (existingContext) {
+    channels.logChannel?.send(`⚠️ [poor-dev] 이전 컨텍스트 발견, 새 실행으로 덮어씁니다. (branch: ${existingContext.branchName})`).catch(() => {})
+  }
   setPhase(channelId, { phase: 'designing', originalPrompt: prompt })
 
   const processingMsg = await message.reply('🧠 poor-dev 설계 단계 시작 (Claude stream-json)...')
@@ -87,17 +110,19 @@ export async function runPoorDev(
       // design 단계 종료만으로는 전체 파이프라인 종료가 아님
     },
     onError: async () => {
+      clearContext(channelId)
       setPhase(channelId, { phase: 'idle' })
       options.onDone?.()
       if (options.tempFiles) await cleanup(options.tempFiles)
     },
-    onDesignComplete: async (designDocRaw: string) => {
+    onDesignComplete: async (designDocRaw: string, designSessionId?: string) => {
       const designDocForPR = designDocRaw.trim()
       const designDocForCoding = designDocForPR.slice(0, 4000)
       const issueTitle = extractIssueTitle(designDocRaw, prompt)
       const issueLabel = extractIssueLabel(designDocRaw)
       let issueNumber = 0
       let branchName = ''
+      const startedAt = new Date().toISOString()
       const workLog: string[] = []
 
       try {
@@ -107,18 +132,44 @@ export async function runPoorDev(
         channels.logChannel?.send('🌿 [poor-dev] feature 브랜치 준비 중...').catch(() => {})
         branchName = checkoutFeatureBranch(issueNumber)
 
+        saveContext({
+          channelId,
+          originalPrompt: prompt,
+          designDoc: designDocForPR,
+          issueNumber,
+          branchName,
+          designSessionId,
+          startedAt,
+        })
+
         setPhase(channelId, {
           phase: 'coding',
           issueNumber,
           branchName,
           designDoc: designDocForPR,
           workLog,
+          designSessionId,
         })
 
         await processingMsg.edit(`🧠 poor-dev 코딩 단계 시작: \`${branchName}\` (Issue #${issueNumber})`).catch(() => {})
 
         const codingChild = runPoorDevCoding(issueNumber, designDocForCoding, prompt, processingMsg, {
           logChannel: channels.logChannel ? { send: (content: string) => channels.logChannel!.send(content) } : undefined,
+          sessionId: designSessionId,
+          onSessionId: (id) => {
+            const current = getPhase(channelId)
+            if (current.phase !== 'coding') return
+            setPhase(channelId, { ...current, designSessionId: id })
+            saveContext({
+              channelId,
+              originalPrompt: prompt,
+              designDoc: designDocForPR,
+              issueNumber,
+              branchName,
+              designSessionId: id,
+              startedAt,
+            })
+          },
           onDone: () => {},
           onWorkLogEntry: (line: string) => {
             const current = getPhase(channelId)
@@ -127,12 +178,23 @@ export async function runPoorDev(
             if (!normalized) return
             if (current.workLog[current.workLog.length - 1] === normalized) return
             if (current.workLog.length >= 20) return
+            const nextWorkLog = [...current.workLog, normalized]
             setPhase(channelId, {
               ...current,
-              workLog: [...current.workLog, normalized],
+              workLog: nextWorkLog,
+            })
+            saveContext({
+              channelId,
+              originalPrompt: prompt,
+              designDoc: designDocForPR,
+              issueNumber,
+              branchName,
+              designSessionId: current.designSessionId,
+              startedAt,
             })
           },
           onError: async () => {
+            clearContext(channelId)
             setPhase(channelId, { phase: 'idle' })
             options.onDone?.()
             if (options.tempFiles) await cleanup(options.tempFiles)
@@ -150,6 +212,7 @@ export async function runPoorDev(
 
             if (code !== 0) {
               await target.send(`❌ poor-dev 코딩 실패 (code=${code ?? 'null'}). 브랜치: \`${branchName}\``)
+              clearContext(channelId)
               setPhase(channelId, { phase: 'idle' })
               options.onDone?.()
               if (options.tempFiles) await cleanup(options.tempFiles)
@@ -157,10 +220,12 @@ export async function runPoorDev(
             }
 
             try {
+              commitPendingChanges(issueNumber, channels.logChannel)
               channels.logChannel?.send('⬆️ [poor-dev] 브랜치 push 중...').catch(() => {})
               pushBranch(branchName)
             } catch (err) {
               await target.send(`❌ 브랜치 push 실패: ${(err as Error).message}\n브랜치: \`${branchName}\``)
+              clearContext(channelId)
               setPhase(channelId, { phase: 'idle' })
               options.onDone?.()
               if (options.tempFiles) await cleanup(options.tempFiles)
@@ -191,6 +256,7 @@ export async function runPoorDev(
             } catch (err) {
               await target.send(`❌ PR 생성 실패: ${(err as Error).message}\n브랜치: \`${branchName}\``)
             } finally {
+              clearContext(channelId)
               setPhase(channelId, { phase: 'idle' })
               options.onDone?.()
               if (options.tempFiles) await cleanup(options.tempFiles)
@@ -201,6 +267,7 @@ export async function runPoorDev(
         options.onProcessSwitch?.(codingChild)
       } catch (err) {
         await processingMsg.edit(`❌ poor-dev 준비 단계 실패: ${(err as Error).message}`).catch(() => {})
+        clearContext(channelId)
         setPhase(channelId, { phase: 'idle' })
         options.onDone?.()
         if (options.tempFiles) await cleanup(options.tempFiles)

--- a/apps/ymm/src/poorDev/runner.ts
+++ b/apps/ymm/src/poorDev/runner.ts
@@ -1,0 +1,212 @@
+import { ChildProcess, execSync } from 'child_process'
+import { Message, TextChannel } from 'discord.js'
+import { GITHUB_REPO, GITHUB_TOKEN, PROJECT_ROOT } from '../config.js'
+import { cleanup } from '../discord/attachments.js'
+import { createIssue, createPR } from '../github/client.js'
+import { buildPRBody } from './prSummary.js'
+import { getPhase, setPhase } from './stateStore.js'
+import { runPoorDevDesign } from './designPhase.js'
+import { runPoorDevCoding } from './codingPhase.js'
+
+type Channels = {
+  logChannel?: TextChannel
+  resultChannel?: TextChannel
+  commandChannel?: TextChannel
+}
+
+type RunPoorDevOptions = {
+  tempFiles?: string[]
+  onProcessSwitch?: (child: ChildProcess) => void
+  onDone?: () => void
+}
+
+function sanitizeTitle(raw: string): string {
+  return raw.replace(/\s+/g, ' ').trim().slice(0, 70) || 'poor-dev task'
+}
+
+function extractSection(doc: string, title: string): string {
+  const escaped = title.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const re = new RegExp(`^##\\s*${escaped}\\s*\\n([\\s\\S]*?)(?=^##\\s|$)`, 'im')
+  return (doc.match(re)?.[1] ?? '').trim()
+}
+
+function extractIssueTitle(doc: string, prompt: string): string {
+  const fromDoc = extractSection(doc, 'ISSUE_TITLE').split('\n')[0]?.trim() ?? ''
+  return sanitizeTitle(fromDoc || prompt)
+}
+
+function extractIssueLabel(doc: string): 'enhancement' | 'task' {
+  const label = extractSection(doc, 'ISSUE_LABEL').split('\n')[0]?.trim().toLowerCase()
+  return label === 'enhancement' ? 'enhancement' : 'task'
+}
+
+function checkoutFeatureBranch(issueNumber: number): string {
+  const branchName = `feat/${issueNumber}-poor-dev`
+  execSync(`git -C "${PROJECT_ROOT}" checkout dev`, { stdio: 'pipe' })
+  execSync(`git -C "${PROJECT_ROOT}" pull origin dev`, { stdio: 'pipe' })
+  try {
+    execSync(`git -C "${PROJECT_ROOT}" checkout -b ${branchName}`, { stdio: 'pipe' })
+  } catch {
+    execSync(`git -C "${PROJECT_ROOT}" checkout ${branchName}`, { stdio: 'pipe' })
+  }
+  return branchName
+}
+
+function pushBranch(branchName: string): void {
+  execSync(`git -C "${PROJECT_ROOT}" push -u origin ${branchName}`, { stdio: 'pipe' })
+}
+
+function buildIssueBodyFromDesign(designDocRaw: string): string {
+  const trimmed = designDocRaw.trim()
+  if (trimmed.length <= 60000) return trimmed
+  return `${trimmed.slice(0, 60000)}\n\n(자동 잘림: designDoc 길이가 너무 길어 60,000자로 제한됨)`
+}
+
+export async function runPoorDev(
+  prompt: string,
+  message: Message,
+  channels: Channels,
+  options: RunPoorDevOptions = {},
+): Promise<ChildProcess | null> {
+  const target = channels.resultChannel ?? (message.channel as TextChannel)
+
+  if (!GITHUB_REPO || !GITHUB_TOKEN) {
+    await target.send('❌ poor-dev 모드는 GITHUB_REPO와 GITHUB_TOKEN 설정이 필요합니다.')
+    return null
+  }
+
+  const channelId = message.channelId
+  setPhase(channelId, { phase: 'designing', originalPrompt: prompt })
+
+  const processingMsg = await message.reply('🧠 poor-dev 설계 단계 시작 (Claude stream-json)...')
+  channels.logChannel?.send('🚀 [poor-dev] 설계 단계 시작').catch(() => {})
+
+  const designChild = runPoorDevDesign(prompt, message, processingMsg, {
+    logChannel: channels.logChannel ? { send: (content: string) => channels.logChannel!.send(content) } : undefined,
+    onDone: async () => {
+      // design 단계 종료만으로는 전체 파이프라인 종료가 아님
+    },
+    onError: async () => {
+      setPhase(channelId, { phase: 'idle' })
+      options.onDone?.()
+      if (options.tempFiles) await cleanup(options.tempFiles)
+    },
+    onDesignComplete: async (designDocRaw: string) => {
+      const designDocForPR = designDocRaw.trim()
+      const designDocForCoding = designDocForPR.slice(0, 4000)
+      const issueTitle = extractIssueTitle(designDocRaw, prompt)
+      const issueLabel = extractIssueLabel(designDocRaw)
+      let issueNumber = 0
+      let branchName = ''
+      const workLog: string[] = []
+
+      try {
+        channels.logChannel?.send('📌 [poor-dev] GitHub 이슈 생성 중...').catch(() => {})
+        issueNumber = await createIssue(issueTitle, buildIssueBodyFromDesign(designDocRaw), [issueLabel])
+
+        channels.logChannel?.send('🌿 [poor-dev] feature 브랜치 준비 중...').catch(() => {})
+        branchName = checkoutFeatureBranch(issueNumber)
+
+        setPhase(channelId, {
+          phase: 'coding',
+          issueNumber,
+          branchName,
+          designDoc: designDocForPR,
+          workLog,
+        })
+
+        await processingMsg.edit(`🧠 poor-dev 코딩 단계 시작: \`${branchName}\` (Issue #${issueNumber})`).catch(() => {})
+
+        const codingChild = runPoorDevCoding(issueNumber, designDocForCoding, prompt, processingMsg, {
+          logChannel: channels.logChannel ? { send: (content: string) => channels.logChannel!.send(content) } : undefined,
+          onDone: () => {},
+          onWorkLogEntry: (line: string) => {
+            const current = getPhase(channelId)
+            if (current.phase !== 'coding') return
+            const normalized = line.trim().slice(0, 200)
+            if (!normalized) return
+            if (current.workLog[current.workLog.length - 1] === normalized) return
+            if (current.workLog.length >= 20) return
+            setPhase(channelId, {
+              ...current,
+              workLog: [...current.workLog, normalized],
+            })
+          },
+          onError: async () => {
+            setPhase(channelId, { phase: 'idle' })
+            options.onDone?.()
+            if (options.tempFiles) await cleanup(options.tempFiles)
+          },
+          onClose: async (code) => {
+            const current = getPhase(channelId)
+            const finalWorkLog = current.phase === 'coding' ? current.workLog : workLog
+
+            // !stop 등 외부 중단으로 phase가 이미 초기화된 경우 후속 처리 생략
+            if (current.phase !== 'coding') {
+              options.onDone?.()
+              if (options.tempFiles) await cleanup(options.tempFiles)
+              return
+            }
+
+            if (code !== 0) {
+              await target.send(`❌ poor-dev 코딩 실패 (code=${code ?? 'null'}). 브랜치: \`${branchName}\``)
+              setPhase(channelId, { phase: 'idle' })
+              options.onDone?.()
+              if (options.tempFiles) await cleanup(options.tempFiles)
+              return
+            }
+
+            try {
+              channels.logChannel?.send('⬆️ [poor-dev] 브랜치 push 중...').catch(() => {})
+              pushBranch(branchName)
+            } catch (err) {
+              await target.send(`❌ 브랜치 push 실패: ${(err as Error).message}\n브랜치: \`${branchName}\``)
+              setPhase(channelId, { phase: 'idle' })
+              options.onDone?.()
+              if (options.tempFiles) await cleanup(options.tempFiles)
+              return
+            }
+
+            try {
+              const prBody = buildPRBody({
+                issueNumber,
+                designDoc: designDocForPR,
+                workLog: finalWorkLog,
+              })
+              const pr = await createPR(
+                {
+                  number: issueNumber,
+                  title: issueTitle,
+                  body: designDocForPR,
+                  labels: [issueLabel],
+                  state: 'open',
+                  url: `https://github.com/${GITHUB_REPO}/issues/${issueNumber}`,
+                },
+                branchName,
+                'dev',
+                prBody,
+                issueTitle,
+              )
+              await target.send(`🎉 poor-dev PR 생성 완료: ${pr.url}`)
+            } catch (err) {
+              await target.send(`❌ PR 생성 실패: ${(err as Error).message}\n브랜치: \`${branchName}\``)
+            } finally {
+              setPhase(channelId, { phase: 'idle' })
+              options.onDone?.()
+              if (options.tempFiles) await cleanup(options.tempFiles)
+            }
+          },
+        })
+
+        options.onProcessSwitch?.(codingChild)
+      } catch (err) {
+        await processingMsg.edit(`❌ poor-dev 준비 단계 실패: ${(err as Error).message}`).catch(() => {})
+        setPhase(channelId, { phase: 'idle' })
+        options.onDone?.()
+        if (options.tempFiles) await cleanup(options.tempFiles)
+      }
+    },
+  })
+
+  return designChild
+}

--- a/apps/ymm/src/poorDev/stateStore.ts
+++ b/apps/ymm/src/poorDev/stateStore.ts
@@ -1,0 +1,18 @@
+export type PoorDevPhase =
+  | { phase: 'idle' }
+  | { phase: 'designing'; originalPrompt: string }
+  | { phase: 'coding'; issueNumber: number; branchName: string; designDoc: string; workLog: string[] }
+
+const store = new Map<string, PoorDevPhase>()
+
+export function getPhase(channelId: string): PoorDevPhase {
+  return store.get(channelId) ?? { phase: 'idle' }
+}
+
+export function setPhase(channelId: string, phase: PoorDevPhase): void {
+  store.set(channelId, phase)
+}
+
+export function clearPhase(channelId: string): void {
+  store.delete(channelId)
+}

--- a/apps/ymm/src/poorDev/stateStore.ts
+++ b/apps/ymm/src/poorDev/stateStore.ts
@@ -1,7 +1,7 @@
 export type PoorDevPhase =
   | { phase: 'idle' }
   | { phase: 'designing'; originalPrompt: string }
-  | { phase: 'coding'; issueNumber: number; branchName: string; designDoc: string; workLog: string[] }
+  | { phase: 'coding'; issueNumber: number; branchName: string; designDoc: string; workLog: string[]; designSessionId?: string }
 
 const store = new Map<string, PoorDevPhase>()
 

--- a/apps/ymm/tests/claude/formatter.test.ts
+++ b/apps/ymm/tests/claude/formatter.test.ts
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { formatToolInput, summarizeToolResult } from '../../src/claude/formatter.js'
+import { stripAnsi } from '../../src/utils/ansi.js'
+
+// formatToolInput
+
+test('formatToolInput: Read shows file path', () => {
+  const result = formatToolInput('Read', { file_path: '/src/foo.ts' })
+  assert.equal(result, '파일: /src/foo.ts')
+})
+
+test('formatToolInput: Write shows file path', () => {
+  const result = formatToolInput('Write', { file_path: '/src/bar.ts' })
+  assert.equal(result, '파일: /src/bar.ts')
+})
+
+test('formatToolInput: Edit shows file path and old_string preview', () => {
+  const result = formatToolInput('Edit', {
+    file_path: '/src/baz.ts',
+    old_string: 'const x = 1',
+  })
+  assert.ok(result.includes('파일: /src/baz.ts'))
+  assert.ok(result.includes('const x = 1'))
+})
+
+test('formatToolInput: Bash shows command', () => {
+  const result = formatToolInput('Bash', { command: 'ls -la' })
+  assert.equal(result, '명령: ls -la')
+})
+
+test('formatToolInput: Glob shows pattern', () => {
+  const result = formatToolInput('Glob', { pattern: '**/*.ts' })
+  assert.equal(result, '패턴: **/*.ts')
+})
+
+test('formatToolInput: Glob shows pattern and path', () => {
+  const result = formatToolInput('Glob', { pattern: '**/*.ts', path: '/src' })
+  assert.equal(result, '패턴: **/*.ts (경로: /src)')
+})
+
+test('formatToolInput: Grep shows search pattern', () => {
+  const result = formatToolInput('Grep', { pattern: 'TODO' })
+  assert.equal(result, '검색: "TODO"')
+})
+
+test('formatToolInput: unknown tool falls back to JSON', () => {
+  const result = formatToolInput('UnknownTool', { key: 'value' })
+  assert.ok(result.includes('value'))
+})
+
+// summarizeToolResult
+
+test('summarizeToolResult: Read success shows line count', () => {
+  const result = stripAnsi(summarizeToolResult('Read', 'line1\nline2\nline3'))
+  assert.ok(result.includes('성공'))
+  assert.ok(result.includes('3줄'))
+})
+
+test('summarizeToolResult: Write/Edit shows 파일 변경 완료', () => {
+  assert.ok(stripAnsi(summarizeToolResult('Write', '')).includes('파일 변경 완료'))
+  assert.ok(stripAnsi(summarizeToolResult('Edit', '')).includes('파일 변경 완료'))
+})
+
+test('summarizeToolResult: Bash shows execution output preview', () => {
+  const result = stripAnsi(summarizeToolResult('Bash', 'output here'))
+  assert.ok(result.includes('실행 완료'))
+  assert.ok(result.includes('output here'))
+})
+
+test('summarizeToolResult: Glob/Grep shows result count', () => {
+  const result = stripAnsi(summarizeToolResult('Glob', 'file1.ts\nfile2.ts'))
+  assert.ok(result.includes('2개 결과'))
+})
+
+test('summarizeToolResult: error content shows 실패', () => {
+  const result = stripAnsi(summarizeToolResult('Read', '{"type":"error","message":"not found"}'))
+  assert.ok(result.includes('실패'))
+})

--- a/apps/ymm/tests/discord/agentStore.test.ts
+++ b/apps/ymm/tests/discord/agentStore.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { getAgent, setAgent } from '../../src/discord/agentStore.js'
+
+test('getAgent returns "claude" as default for unknown channelId', () => {
+  assert.equal(getAgent('unknown-ch-agent'), 'claude')
+})
+
+test('setAgent and getAgent round-trip for codex', () => {
+  setAgent('ch-agent-1', 'codex')
+  assert.equal(getAgent('ch-agent-1'), 'codex')
+})
+
+test('setAgent and getAgent round-trip for poor-dev', () => {
+  setAgent('ch-agent-2', 'poor-dev')
+  assert.equal(getAgent('ch-agent-2'), 'poor-dev')
+})
+
+test('setAgent overwrites previous value', () => {
+  setAgent('ch-agent-3', 'codex')
+  setAgent('ch-agent-3', 'claude')
+  assert.equal(getAgent('ch-agent-3'), 'claude')
+})

--- a/apps/ymm/tests/discord/processStore.test.ts
+++ b/apps/ymm/tests/discord/processStore.test.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict'
+import type { ChildProcess } from 'node:child_process'
+import test from 'node:test'
+import { clearProcess, getProcess, killProcess, setProcess } from '../../src/discord/processStore.js'
+
+function makeStub(): ChildProcess {
+  return { kill: () => {} } as unknown as ChildProcess
+}
+
+test('getProcess returns undefined for unknown channelId', () => {
+  assert.equal(getProcess('unknown-ch-proc'), undefined)
+})
+
+test('setProcess and getProcess round-trip', () => {
+  const stub = makeStub()
+  setProcess('ch-proc-1', stub)
+  assert.strictEqual(getProcess('ch-proc-1'), stub)
+})
+
+test('clearProcess removes the process', () => {
+  setProcess('ch-proc-2', makeStub())
+  clearProcess('ch-proc-2')
+  assert.equal(getProcess('ch-proc-2'), undefined)
+})
+
+test('killProcess returns true and removes process when it exists', () => {
+  let killed = false
+  const stub = { kill: () => { killed = true } } as unknown as ChildProcess
+  setProcess('ch-proc-3', stub)
+
+  const result = killProcess('ch-proc-3')
+
+  assert.equal(result, true)
+  assert.equal(killed, true)
+  assert.equal(getProcess('ch-proc-3'), undefined)
+})
+
+test('killProcess returns false when process does not exist', () => {
+  const result = killProcess('ch-proc-nonexistent')
+  assert.equal(result, false)
+})

--- a/apps/ymm/tests/discord/sessionStore.test.ts
+++ b/apps/ymm/tests/discord/sessionStore.test.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { clearSession, getSession, setSession } from '../../src/discord/sessionStore.js'
+
+test('getSession returns undefined for unknown channelId', () => {
+  assert.equal(getSession('unknown-ch-sess'), undefined)
+})
+
+test('setSession and getSession round-trip', () => {
+  setSession('ch-sess-1', 'session-abc')
+  assert.equal(getSession('ch-sess-1'), 'session-abc')
+})
+
+test('clearSession removes the session', () => {
+  setSession('ch-sess-2', 'session-xyz')
+  clearSession('ch-sess-2')
+  assert.equal(getSession('ch-sess-2'), undefined)
+})
+
+test('clearSession on unknown channelId is a no-op', () => {
+  clearSession('nonexistent-sess-ch')
+  assert.equal(getSession('nonexistent-sess-ch'), undefined)
+})
+
+test('setSession overwrites previous sessionId', () => {
+  setSession('ch-sess-3', 'session-old')
+  setSession('ch-sess-3', 'session-new')
+  assert.equal(getSession('ch-sess-3'), 'session-new')
+})

--- a/apps/ymm/tests/poorDev/contextStore.test.ts
+++ b/apps/ymm/tests/poorDev/contextStore.test.ts
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+// config.ts reads PROJECT_ROOT and DISCORD_TOKEN at module load time.
+// Set env vars before dynamic import so CONTEXT_PATH points to a temp dir.
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ymm-ctx-test-'))
+process.env.DISCORD_TOKEN = 'test-token'
+process.env.PROJECT_ROOT = tmpDir
+
+const { saveContext, loadContext, clearContext } = await import(
+  '../../src/poorDev/contextStore.js'
+)
+
+const base = {
+  channelId: 'ch-1',
+  originalPrompt: 'test prompt',
+  designDoc: 'design document',
+  issueNumber: 42,
+  branchName: 'feature/42-test',
+  startedAt: '2026-01-01T00:00:00Z',
+}
+
+test('saveContext and loadContext round-trip', () => {
+  saveContext(base)
+  const loaded = loadContext()
+  assert.ok(loaded)
+  assert.equal(loaded.channelId, base.channelId)
+  assert.equal(loaded.originalPrompt, base.originalPrompt)
+  assert.equal(loaded.issueNumber, base.issueNumber)
+  assert.equal(loaded.branchName, base.branchName)
+  assert.equal(loaded.startedAt, base.startedAt)
+  clearContext()
+})
+
+test('loadContext returns null when no context file exists', () => {
+  clearContext()
+  assert.equal(loadContext(), null)
+})
+
+test('clearContext removes context for matching channelId', () => {
+  saveContext(base)
+  clearContext('ch-1')
+  assert.equal(loadContext(), null)
+})
+
+test('clearContext does not remove context for different channelId', () => {
+  saveContext(base)
+  clearContext('ch-999')
+  assert.ok(loadContext())
+  clearContext()
+})
+
+test('saveContext truncates oversized designDoc to 60000 chars', () => {
+  const longDoc = 'x'.repeat(70000)
+  saveContext({ ...base, designDoc: longDoc })
+  const loaded = loadContext()
+  assert.ok(loaded)
+  assert.ok(loaded.designDoc.length <= 60000)
+  clearContext()
+})
+
+test('saveContext preserves optional designSessionId', () => {
+  saveContext({ ...base, designSessionId: 'sess-abc' })
+  const loaded = loadContext()
+  assert.ok(loaded)
+  assert.equal(loaded.designSessionId, 'sess-abc')
+  clearContext()
+})
+
+// Cleanup temp dir after all tests
+process.on('exit', () => {
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})

--- a/apps/ymm/tests/poorDev/logFilter.test.ts
+++ b/apps/ymm/tests/poorDev/logFilter.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { filterCodingLine, resetCodingLogFilterState } from '../../src/poorDev/logFilter.js'
+
+test('filterCodingLine emits short plain text', () => {
+  resetCodingLogFilterState()
+  const result = filterCodingLine('작업 완료')
+  assert.equal(result.emit, true)
+})
+
+test('filterCodingLine suppresses code snippet (const declaration)', () => {
+  resetCodingLogFilterState()
+  const result = filterCodingLine('const x = foo()')
+  assert.equal(result.emit, false)
+})
+
+test('filterCodingLine suppresses lines inside code block', () => {
+  resetCodingLogFilterState()
+  filterCodingLine('```') // opens code block
+  const result = filterCodingLine('plain text inside block')
+  assert.equal(result.emit, false)
+})
+
+test('filterCodingLine closes code block on second backtick fence', () => {
+  resetCodingLogFilterState()
+  filterCodingLine('```') // opens
+  filterCodingLine('```') // closes
+  const result = filterCodingLine('작업 완료')
+  assert.equal(result.emit, true)
+})
+
+test('resetCodingLogFilterState clears code block state', () => {
+  resetCodingLogFilterState()
+  filterCodingLine('```') // opens code block
+  resetCodingLogFilterState()
+  // After reset, normal lines should be evaluated as usual again
+  const result = filterCodingLine('작업 완료')
+  assert.equal(result.emit, true)
+})
+
+test('filterCodingLine emits error keyword lines', () => {
+  resetCodingLogFilterState()
+  const result = filterCodingLine('error: file not found')
+  assert.equal(result.emit, true)
+})
+
+test('filterCodingLine emits summary keyword line', () => {
+  resetCodingLogFilterState()
+  const result = filterCodingLine('파일 수정 완료되었습니다')
+  assert.equal(result.emit, true)
+})
+
+test('filterCodingLine suppresses diff markers', () => {
+  resetCodingLogFilterState()
+  const result = filterCodingLine('diff --git a/foo b/foo')
+  assert.equal(result.emit, false)
+})
+
+test('filterCodingLine suppresses diff content (+/- lines)', () => {
+  resetCodingLogFilterState()
+  const added = filterCodingLine('+const x = 1')
+  assert.equal(added.emit, false)
+})

--- a/apps/ymm/tests/poorDev/stateStore.test.ts
+++ b/apps/ymm/tests/poorDev/stateStore.test.ts
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { clearPhase, getPhase, setPhase } from '../../src/poorDev/stateStore.js'
+
+test('getPhase returns idle for unknown channelId', () => {
+  assert.deepEqual(getPhase('unknown-ch'), { phase: 'idle' })
+})
+
+test('setPhase and getPhase round-trip for designing phase', () => {
+  setPhase('ch-state-1', { phase: 'designing', originalPrompt: 'do something' })
+  assert.deepEqual(getPhase('ch-state-1'), {
+    phase: 'designing',
+    originalPrompt: 'do something',
+  })
+})
+
+test('setPhase and getPhase round-trip for coding phase', () => {
+  const phase = {
+    phase: 'coding' as const,
+    issueNumber: 42,
+    branchName: 'feature/42-test',
+    designDoc: 'design doc content',
+    workLog: ['step 1'],
+  }
+  setPhase('ch-state-2', phase)
+  assert.deepEqual(getPhase('ch-state-2'), phase)
+})
+
+test('clearPhase removes the phase (returns idle)', () => {
+  setPhase('ch-state-3', { phase: 'designing', originalPrompt: 'test' })
+  clearPhase('ch-state-3')
+  assert.deepEqual(getPhase('ch-state-3'), { phase: 'idle' })
+})
+
+test('clearPhase on unknown channelId is a no-op', () => {
+  clearPhase('nonexistent-ch')
+  assert.deepEqual(getPhase('nonexistent-ch'), { phase: 'idle' })
+})

--- a/apps/ymm/tests/utils/ansi.test.ts
+++ b/apps/ymm/tests/utils/ansi.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { splitIntoChunks, stripAnsi, truncate } from '../../src/utils/ansi.js'
+
+test('stripAnsi removes ANSI escape codes', () => {
+  assert.equal(stripAnsi('\x1b[32mhello\x1b[0m'), 'hello')
+  assert.equal(stripAnsi('\x1b[1m\x1b[90mtext\x1b[0m'), 'text')
+})
+
+test('stripAnsi passes through plain text unchanged', () => {
+  assert.equal(stripAnsi('plain text'), 'plain text')
+  assert.equal(stripAnsi(''), '')
+})
+
+test('truncate returns original string when within limit', () => {
+  assert.equal(truncate('hello', 10), 'hello')
+  assert.equal(truncate('hello', 5), 'hello')
+})
+
+test('truncate truncates and appends marker when over limit', () => {
+  const result = truncate('hello world', 5)
+  assert.equal(result, 'hello\n...(잘림)')
+})
+
+test('splitIntoChunks splits string into chunks of given size', () => {
+  assert.deepEqual(splitIntoChunks('abcdef', 2), ['ab', 'cd', 'ef'])
+  assert.deepEqual(splitIntoChunks('abcde', 2), ['ab', 'cd', 'e'])
+})
+
+test('splitIntoChunks returns empty array for empty string', () => {
+  assert.deepEqual(splitIntoChunks('', 5), [])
+})


### PR DESCRIPTION
closes #170

## 작업 내용
- Let me implement the test files as described in the design document. I'll follow the implementation plan step by step.
- Since we're using ESM with Node.js `--import tsx`, dynamic imports won't help because the module will still get loaded and evaluated.
- Writing the contextStore test file... Writing test cases...
- For the formatter tests, I'm importing the stripAnsi utility to remove ANSI codes from the summarizeToolResult output so I can verify the actual content in assertions.
- Now I'll create the test directory structure and write out all the test files systematically, starting with the simpler utilities and working up to the more complex ones.
- The key issue is that `dotenv/config` loads the `.env` file from the current working directory when tests run, which means `DISCORD_TOKEN` might already be set depending on where the test is executed
- CLAUDE.md의 체크리스트를 확인하고 구현합니다. 현재 `feat/170-poor-dev` 브랜치에서 신규 테스트 파일만 추가합니다.
- 이제 테스트를 실행합니다.
- 53개 전부 pass. 커밋합니다.
- 완료. 결과 요약:
- **추가된 파일 (8개)**
- | 파일 | 테스트 수 |
- |------|----------|
- | `tests/utils/ansi.test.ts` | 6 |
- | `tests/poorDev/logFilter.test.ts` | 9 |
- | `tests/poorDev/stateStore.test.ts` | 5 |
- | `tests/poorDev/contextStore.test.ts` | 6 |
- | `tests/claude/formatter.test.ts` | 13 |
- | `tests/discord/agentStore.test.ts` | 4 |
- | `tests/discord/sessionStore.test.ts` | 5 |

## 설계 기반
### 목표
`apps/ymm` 의 순수 함수·스토어·파일 I/O 모듈에 대해 Node.js 내장 테스트 러너(`node:test`) 기반 단위 테스트를 추가한다. 현재 `tests/sharedAgentContext.test.ts` 하나만 존재하며, 핵심 비즈니스 로직에 커버리지가 없다.
### 완료 조건
1. `pnpm --filter ymm test` 실행 시 전체 테스트가 pass (0 failures)