### PR TITLE
초대 링크 플로우 재설계 — 수락/거절 UI, orga 선택 페이지 pending 표시

### DIFF
--- a/apps/assassin/src/app/invite/accept/page.tsx
+++ b/apps/assassin/src/app/invite/accept/page.tsx
@@ -2,8 +2,8 @@ import { redirect } from "next/navigation";
 import Link from "next/link";
 import { createServerSupabaseClient } from "@libs/supabase/server";
 import OrgService from "@features/org/service";
+import { InviteAcceptClient } from "@features/org/components/InviteAcceptClient";
 
-// 에러 코드 → 유저에게 보여줄 메시지 매핑
 function getErrorContent(code: string): { title: string; description: string } {
   switch (code) {
     case "INVALID_TOKEN":
@@ -58,11 +58,11 @@ function InviteErrorCard({ code }: { code: string }) {
 export default async function InviteAcceptPage({
   searchParams,
 }: {
-  searchParams: Promise<{ token?: string }>;
+  searchParams: Promise<{ token?: string; id?: string }>;
 }) {
-  const { token } = await searchParams;
+  const { token, id } = await searchParams;
 
-  if (!token) {
+  if (!token && !id) {
     return <InviteErrorCard code="INVALID_TOKEN" />;
   }
 
@@ -71,18 +71,23 @@ export default async function InviteAcceptPage({
     data: { user },
   } = await supabase.auth.getUser();
 
-  // 미인증 → 회원가입(신규) 또는 로그인(기존) 후 이 페이지로 돌아오도록 next 파라미터 전달
   if (!user || !user.email) {
-    redirect(`/signup?next=${encodeURIComponent(`/invite/accept?token=${token}`)}`);
+    if (token) {
+      // 미인증 + 이메일 링크: 로그인 후 orga 선택 페이지로 이동
+      // (선택 페이지에서 pending 초대 목록을 이메일로 조회해 표시)
+      redirect("/signup");
+    } else {
+      redirect(`/signup?next=${encodeURIComponent(`/invite/accept?id=${id}`)}`);
+    }
   }
 
-  let orgSlug: string;
+  let info: { invitationId: string; orgName: string };
   try {
-    const org = await OrgService.acceptInvitation(token, user.id, user.email);
-    orgSlug = org.slug;
+    info = await OrgService.getInvitationInfo({ token, id }, user.email);
   } catch (error) {
     const code = error instanceof Error ? error.message : "ERROR";
     return <InviteErrorCard code={code} />;
   }
-  redirect(`/org/${orgSlug}`);
+
+  return <InviteAcceptClient invitationId={info.invitationId} orgName={info.orgName} />;
 }

--- a/apps/assassin/src/app/page.tsx
+++ b/apps/assassin/src/app/page.tsx
@@ -1,6 +1,6 @@
 import { redirect } from "next/navigation";
 import { createServerSupabaseClient } from "@libs/supabase/server";
-import { getUserOrgsAction } from "@features/org/actions";
+import { getUserOrgsAction, getPendingInvitationsForUserAction } from "@features/org/actions";
 import { OrgSelectPageClient } from "@/features/org/components/OrgSelectPageClient";
 
 export default async function HomePage() {
@@ -13,10 +13,16 @@ export default async function HomePage() {
     redirect("/login");
   }
 
-  const orgs = await getUserOrgsAction(user.id).catch((e) => {
-    console.error("[Home] getUserOrgsAction 실패:", e);
-    return [];
-  });
+  const [orgs, pendingInvitations] = await Promise.all([
+    getUserOrgsAction(user.id).catch((e) => {
+      console.error("[Home] getUserOrgsAction 실패:", e);
+      return [];
+    }),
+    getPendingInvitationsForUserAction().catch((e) => {
+      console.error("[Home] getPendingInvitationsForUserAction 실패:", e);
+      return [];
+    }),
+  ]);
 
-  return <OrgSelectPageClient orgs={orgs} />;
+  return <OrgSelectPageClient orgs={orgs} pendingInvitations={pendingInvitations} />;
 }

--- a/apps/assassin/src/features/org/actions.ts
+++ b/apps/assassin/src/features/org/actions.ts
@@ -104,9 +104,10 @@ export const inviteMemberAction = async (
       ...(emailError && { emailError }),
     };
   } catch (error) {
+    const message = error instanceof Error ? error.message : "초대 생성에 실패했습니다.";
     return {
       success: false,
-      error: error instanceof Error ? error.message : "초대 생성에 실패했습니다.",
+      error: message === "ALREADY_INVITED" ? "이미 유효한 초대가 진행 중입니다." : message,
     };
   }
 };
@@ -138,4 +139,39 @@ export const leaveOrgAction = async (orgId: string) => {
 export const getPendingInvitationsAction = async (orgId: string) => {
   const userId = await getCurrentUserId();
   return await OrgService.getPendingInvitations(orgId, userId);
+};
+
+export const getInvitationInfoAction = async (params: { token?: string; id?: string }) => {
+  const supabase = await createServerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  return await OrgService.getInvitationInfo(params, user?.email ?? undefined);
+};
+
+export const acceptInvitationByIdAction = async (invitationId: string) => {
+  const supabase = await createServerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user || !user.email) throw new Error("인증이 필요합니다.");
+  return await OrgService.acceptInvitationById(invitationId, user.id, user.email);
+};
+
+export const cancelInvitationByInviteeAction = async (invitationId: string) => {
+  const supabase = await createServerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user || !user.email) throw new Error("인증이 필요합니다.");
+  await OrgService.cancelInvitationByInvitee(invitationId, user.email);
+};
+
+export const getPendingInvitationsForUserAction = async () => {
+  const supabase = await createServerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user?.email) return [];
+  return await OrgService.getPendingInvitationsForUser(user.email);
 };

--- a/apps/assassin/src/features/org/components/InviteAcceptClient.tsx
+++ b/apps/assassin/src/features/org/components/InviteAcceptClient.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { acceptInvitationByIdAction, cancelInvitationByInviteeAction } from "../actions";
+
+interface Props {
+  invitationId: string;
+  orgName: string;
+}
+
+export function InviteAcceptClient({ invitationId, orgName }: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [cancelled, setCancelled] = useState(false);
+
+  const handleAccept = () => {
+    startTransition(async () => {
+      try {
+        const org = await acceptInvitationByIdAction(invitationId);
+        router.push(`/org/${org.slug}/season`);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "오류가 발생했습니다.");
+      }
+    });
+  };
+
+  const handleCancel = () => {
+    startTransition(async () => {
+      try {
+        await cancelInvitationByInviteeAction(invitationId);
+        setCancelled(true);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "오류가 발생했습니다.");
+      }
+    });
+  };
+
+  if (cancelled) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-50 dark:bg-slate-900 px-4">
+        <div className="w-full max-w-sm text-center space-y-4">
+          <h1 className="text-xl font-semibold text-slate-900 dark:text-slate-50">초대를 거절했습니다</h1>
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            {orgName} 조직의 초대를 거절했습니다.
+          </p>
+          <Link href="/" className="block text-sm text-blue-500 hover:text-blue-600">
+            홈으로 돌아가기
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-slate-50 dark:bg-slate-900 px-4">
+      <div className="w-full max-w-sm space-y-6">
+        <div className="text-center space-y-2">
+          <h1 className="text-xl font-semibold text-slate-900 dark:text-slate-50">{orgName}</h1>
+          <p className="text-sm text-slate-500 dark:text-slate-400">조직에 참가하시겠습니까?</p>
+        </div>
+        {error && <p className="text-sm text-red-500 text-center">{error}</p>}
+        <div className="flex gap-3">
+          <Button
+            variant="outline"
+            className="flex-1"
+            disabled={isPending}
+            onClick={handleCancel}
+          >
+            거절
+          </Button>
+          <Button
+            className="flex-1 bg-blue-500 hover:bg-blue-600 text-white"
+            disabled={isPending}
+            onClick={handleAccept}
+          >
+            {isPending ? "처리 중..." : "수락"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/assassin/src/features/org/components/MembersPageClient.tsx
+++ b/apps/assassin/src/features/org/components/MembersPageClient.tsx
@@ -92,20 +92,29 @@ export function MembersPageClient({ org, members, pendingInvitations, currentUse
     });
   };
 
-  const handleResendInvitation = (targetEmail: string) => {
+  const handleReInvite = (invitationId: string, email: string) => {
     setInviteError(null);
     setInviteWarning(null);
 
     startTransition(async () => {
-      const result = await inviteMemberAction(org.id, { email: targetEmail, role: "MEMBER" });
+      addOptimisticInvitation({ type: "remove", id: invitationId });
+      const result = await inviteMemberAction(org.id, { email, role: "MEMBER" });
       if (!result.success) {
         setInviteError(result.error);
         return;
       }
-
+      addOptimisticInvitation({
+        type: "add",
+        invitation: {
+          id: result.data.id,
+          email: result.data.email,
+          expiresAt: result.data.expiresAt,
+          emailSentAt: result.emailSent ? new Date() : null,
+        },
+      });
       if (!result.emailSent) {
         setInviteWarning(
-          `재발송 초대가 생성되었지만 이메일 발송에 실패했습니다. (${result.emailError ?? "알 수 없는 오류"})`,
+          `초대가 재발급되었지만 이메일 발송에 실패했습니다. (${result.emailError ?? "알 수 없는 오류"})`,
         );
       }
       router.refresh();
@@ -171,46 +180,56 @@ export function MembersPageClient({ org, members, pendingInvitations, currentUse
                     초대 대기 중 ({optimisticInvitations.length})
                   </h2>
                   <ul className="flex flex-col gap-2">
-                    {optimisticInvitations.map((inv) => (
-                      <li
-                        key={inv.id}
-                        className="flex items-center justify-between rounded-lg border border-slate-200 dark:border-slate-800 px-4 py-3"
-                      >
-                        <div>
-                          <p className="text-sm font-medium text-slate-900 dark:text-slate-50">
-                            {inv.email}
-                          </p>
-                          <p className="text-xs text-slate-500 dark:text-slate-400">
-                            만료: {new Date(inv.expiresAt).toLocaleDateString("ko-KR")}
-                          </p>
-                          {!inv.emailSentAt && (
-                            <p className="text-xs text-yellow-600 dark:text-yellow-500 mt-0.5">
-                              이메일 미발송
+                    {optimisticInvitations.map((inv) => {
+                      const isExpired = new Date(inv.expiresAt) <= new Date();
+                      return (
+                        <li
+                          key={inv.id}
+                          className="flex items-center justify-between rounded-lg border border-slate-200 dark:border-slate-800 px-4 py-3"
+                        >
+                          <div>
+                            <p className="text-sm font-medium text-slate-900 dark:text-slate-50">
+                              {inv.email}
                             </p>
+                            {isExpired ? (
+                              <p className="text-xs text-red-500 dark:text-red-400 mt-0.5">
+                                만료됨 ({new Date(inv.expiresAt).toLocaleDateString("ko-KR")})
+                              </p>
+                            ) : (
+                              <p className="text-xs text-slate-500 dark:text-slate-400">
+                                만료: {new Date(inv.expiresAt).toLocaleDateString("ko-KR")}
+                              </p>
+                            )}
+                            {!inv.emailSentAt && (
+                              <p className="text-xs text-yellow-600 dark:text-yellow-500 mt-0.5">
+                                이메일 미발송
+                              </p>
+                            )}
+                          </div>
+                          {isExpired ? (
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              disabled={isPending}
+                              onClick={() => handleReInvite(inv.id, inv.email)}
+                              className="text-slate-700 border-slate-300 hover:bg-slate-100 dark:text-slate-200 dark:border-slate-700 dark:hover:bg-slate-800"
+                            >
+                              재초대
+                            </Button>
+                          ) : (
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              disabled={isPending}
+                              onClick={() => handleCancelInvitation(inv.id)}
+                              className="text-red-500 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-950"
+                            >
+                              취소
+                            </Button>
                           )}
-                        </div>
-                        <div className="flex items-center gap-2">
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            disabled={isPending}
-                            onClick={() => handleResendInvitation(inv.email)}
-                            className="text-slate-700 border-slate-300 hover:bg-slate-100 dark:text-slate-200 dark:border-slate-700 dark:hover:bg-slate-800"
-                          >
-                            {inv.emailSentAt ? "이메일 재발송" : "이메일 발송"}
-                          </Button>
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            disabled={isPending}
-                            onClick={() => handleCancelInvitation(inv.id)}
-                            className="text-red-500 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-950"
-                          >
-                            취소
-                          </Button>
-                        </div>
-                      </li>
-                    ))}
+                        </li>
+                      );
+                    })}
                   </ul>
                 </section>
                 <Separator />

--- a/apps/assassin/src/features/org/components/OrgSelectPageClient.tsx
+++ b/apps/assassin/src/features/org/components/OrgSelectPageClient.tsx
@@ -1,19 +1,27 @@
 "use client";
 
 import Link from "next/link";
-import { Building2, ChevronRight } from "lucide-react";
+import { Building2, ChevronRight, Mail } from "lucide-react";
 import type { Org } from "@/features/org/schema";
 import { useRealtimeOrgSync } from "@/features/org/hooks/useRealtimeOrgSync";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { LogoutButton } from "@/components/navigation/LogoutButton";
 
+type PendingInvitation = {
+  id: string;
+  org: { name: string };
+};
+
 interface OrgSelectPageClientProps {
   orgs: Org[];
+  pendingInvitations: PendingInvitation[];
 }
 
-export function OrgSelectPageClient({ orgs }: OrgSelectPageClientProps) {
+export function OrgSelectPageClient({ orgs, pendingInvitations }: OrgSelectPageClientProps) {
   useRealtimeOrgSync();
+
+  const hasContent = orgs.length > 0 || pendingInvitations.length > 0;
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-slate-50 dark:bg-slate-900 px-4">
@@ -24,7 +32,7 @@ export function OrgSelectPageClient({ orgs }: OrgSelectPageClientProps) {
           </div>
           <CardTitle className="text-xl text-slate-900 dark:text-slate-50">시작하기</CardTitle>
           <CardDescription className="text-slate-500 dark:text-slate-400">
-            {orgs.length > 0
+            {hasContent
               ? "소속된 조직을 선택하세요."
               : "소속된 조직이 없습니다. 새 조직을 만들거나 초대를 확인하세요."}
           </CardDescription>
@@ -42,6 +50,28 @@ export function OrgSelectPageClient({ orgs }: OrgSelectPageClientProps) {
                   <div className="flex items-center gap-1">
                     <span className="text-xs text-slate-400">{org.slug}</span>
                     <ChevronRight className="h-4 w-4 text-slate-400" />
+                  </div>
+                </Link>
+              ))}
+            </div>
+          )}
+          {pendingInvitations.length > 0 && (
+            <div className="flex flex-col gap-2">
+              <p className="text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wider">
+                초대받은 조직
+              </p>
+              {pendingInvitations.map((inv) => (
+                <Link
+                  key={inv.id}
+                  href={`/invite/accept?id=${inv.id}`}
+                  className="flex items-center justify-between px-4 py-3 bg-blue-50 dark:bg-blue-950 border border-blue-200 dark:border-blue-800 rounded-lg hover:border-blue-400 hover:shadow-sm transition-all"
+                >
+                  <span className="font-medium text-slate-900 dark:text-slate-50">
+                    {inv.org.name}
+                  </span>
+                  <div className="flex items-center gap-1">
+                    <Mail className="h-3.5 w-3.5 text-blue-500" />
+                    <span className="text-xs text-blue-500">초대 대기</span>
                   </div>
                 </Link>
               ))}

--- a/apps/assassin/src/features/org/repository.ts
+++ b/apps/assassin/src/features/org/repository.ts
@@ -3,6 +3,10 @@ import { Prisma } from "../../generated/prisma/client";
 import { CreateOrgPayload, UpdateOrgPayload } from "./schema";
 import crypto from "crypto";
 
+function hashToken(token: string): string {
+  return crypto.createHash("sha256").update(token).digest("hex");
+}
+
 async function getOrgById(id: string) {
   return await prisma.org.findUnique({ where: { id } });
 }
@@ -87,29 +91,66 @@ async function createInvitation(
   role: "MEMBER",
   tx?: Prisma.TransactionClient,
 ) {
-  const token = crypto.randomBytes(32).toString("hex");
+  const plainToken = crypto.randomBytes(32).toString("hex");
+  const tokenHash = hashToken(plainToken);
   const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000); // 7일
   const client = tx ?? prisma;
 
-  return await client.orgInvitation.create({
+  const record = await client.orgInvitation.create({
     data: {
       orgId,
       email,
-      token,
+      token: tokenHash,
       role,
       status: "PENDING",
       expiresAt,
     },
   });
+
+  // DB에는 해시 저장, 호출자에게는 평문 토큰 반환 (이메일 URL용)
+  return { ...record, token: plainToken };
 }
 
 async function getInvitationByToken(token: string) {
-  return await prisma.orgInvitation.findUnique({ where: { token } });
+  const tokenHash = hashToken(token);
+  return await prisma.orgInvitation.findUnique({ where: { token: tokenHash } });
+}
+
+async function getInvitationById(id: string) {
+  return await prisma.orgInvitation.findUnique({ where: { id } });
+}
+
+async function getPendingInvitationsByEmail(email: string) {
+  return await prisma.orgInvitation.findMany({
+    where: { email, status: "PENDING", expiresAt: { gt: new Date() } },
+    include: { org: true },
+    orderBy: { createdAt: "desc" },
+  });
+}
+
+async function getValidPendingInvitationByEmail(orgId: string, email: string) {
+  return await prisma.orgInvitation.findFirst({
+    where: { orgId, email, status: "PENDING", expiresAt: { gt: new Date() } },
+  });
 }
 
 async function getPendingInvitationsByOrg(orgId: string) {
   return await prisma.orgInvitation.findMany({
-    where: { orgId, status: "PENDING", expiresAt: { gt: new Date() } },
+    where: { orgId, status: "PENDING" },
+    orderBy: { createdAt: "desc" },
+  });
+}
+
+// 만료된 PENDING 초대를 EXPIRED로 정리 — 재초대 전 호출
+async function markExpiredInvitations(
+  orgId: string,
+  email: string,
+  tx?: Prisma.TransactionClient,
+): Promise<void> {
+  const client = tx ?? prisma;
+  await client.orgInvitation.updateMany({
+    where: { orgId, email, status: "PENDING", expiresAt: { lte: new Date() } },
+    data: { status: "EXPIRED" },
   });
 }
 
@@ -144,19 +185,6 @@ async function markInvitationEmailSent(id: string): Promise<void> {
   });
 }
 
-// 동일 (orgId, email)의 PENDING 초대를 모두 취소 — 재초대 시 호출
-async function cancelPendingInvitationsByEmail(
-  orgId: string,
-  email: string,
-  tx?: Prisma.TransactionClient,
-): Promise<void> {
-  const client = tx ?? prisma;
-  await client.orgInvitation.updateMany({
-    where: { orgId, email, status: "PENDING" },
-    data: { status: "CANCELLED" },
-  });
-}
-
 const OrgRepository = {
   getOrgById,
   getOrgBySlug,
@@ -171,10 +199,13 @@ const OrgRepository = {
   removeMember,
   createInvitation,
   getInvitationByToken,
+  getInvitationById,
+  getValidPendingInvitationByEmail,
   getPendingInvitationsByOrg,
+  getPendingInvitationsByEmail,
+  markExpiredInvitations,
   updateInvitationStatus,
   findUserIdByEmail,
-  cancelPendingInvitationsByEmail,
   markInvitationEmailSent,
   getProfileById,
 };

--- a/apps/assassin/src/features/org/service.ts
+++ b/apps/assassin/src/features/org/service.ts
@@ -61,9 +61,15 @@ const inviteMember = async (orgId: string, requesterId: string, input: InviteMem
     }
   }
 
-  // 기존 PENDING 초대 취소 후 재생성 — 두 작업을 트랜잭션으로 묶어 원자성 보장
+  // 유효한 초대가 이미 존재하면 중복 초대 차단
+  const validPending = await OrgRepository.getValidPendingInvitationByEmail(orgId, email);
+  if (validPending) {
+    throw new Error("ALREADY_INVITED");
+  }
+
+  // 만료된 PENDING 정리 후 새 초대 생성
   return await prisma.$transaction(async (tx) => {
-    await OrgRepository.cancelPendingInvitationsByEmail(orgId, email, tx);
+    await OrgRepository.markExpiredInvitations(orgId, email, tx);
     return await OrgRepository.createInvitation(orgId, email, "MEMBER", tx);
   });
 };
@@ -125,6 +131,67 @@ const leaveOrg = async (orgId: string, userId: string) => {
   await OrgRepository.removeMember(orgId, userId);
 };
 
+const getInvitationInfo = async (params: { token?: string; id?: string }, userEmail?: string) => {
+  let invitation;
+  if (params.token) {
+    invitation = await OrgRepository.getInvitationByToken(params.token);
+  } else if (params.id) {
+    invitation = await OrgRepository.getInvitationById(params.id);
+  } else {
+    throw new Error("INVALID_TOKEN");
+  }
+
+  if (!invitation) throw new Error("INVALID_TOKEN");
+  if (invitation.status === "ACCEPTED") throw new Error("ALREADY_ACCEPTED");
+  if (invitation.status === "CANCELLED") throw new Error("REVOKED");
+  if (invitation.status === "EXPIRED" || new Date() > invitation.expiresAt)
+    throw new Error("EXPIRED");
+
+  if (params.id && userEmail && invitation.email !== userEmail.toLowerCase().trim()) {
+    throw new Error("EMAIL_MISMATCH");
+  }
+
+  const org = await OrgRepository.getOrgById(invitation.orgId);
+  return { invitationId: invitation.id, orgName: org!.name };
+};
+
+const acceptInvitationById = async (invitationId: string, userId: string, userEmail: string) => {
+  const invitation = await OrgRepository.getInvitationById(invitationId);
+  if (!invitation) throw new Error("INVALID_TOKEN");
+  if (invitation.status === "ACCEPTED") throw new Error("ALREADY_ACCEPTED");
+  if (invitation.status === "CANCELLED") throw new Error("REVOKED");
+  if (invitation.status === "EXPIRED" || new Date() > invitation.expiresAt) {
+    if (invitation.status !== "EXPIRED") {
+      await OrgRepository.updateInvitationStatus(invitation.id, "EXPIRED");
+    }
+    throw new Error("EXPIRED");
+  }
+  if (invitation.email !== userEmail.toLowerCase().trim()) throw new Error("EMAIL_MISMATCH");
+
+  await prisma.$transaction(async (tx) => {
+    const existingMember = await OrgRepository.getMember(invitation.orgId, userId);
+    if (!existingMember) {
+      await OrgRepository.addMember(invitation.orgId, userId, "MEMBER", tx);
+    }
+    await OrgRepository.updateInvitationStatus(invitation.id, "ACCEPTED", tx);
+  });
+
+  const org = await OrgRepository.getOrgById(invitation.orgId);
+  return org!;
+};
+
+const cancelInvitationByInvitee = async (invitationId: string, userEmail: string) => {
+  const invitation = await OrgRepository.getInvitationById(invitationId);
+  if (!invitation) throw new Error("INVALID_TOKEN");
+  if (invitation.email !== userEmail.toLowerCase().trim()) throw new Error("EMAIL_MISMATCH");
+  if (invitation.status !== "PENDING") throw new Error("REVOKED");
+  await OrgRepository.updateInvitationStatus(invitationId, "CANCELLED");
+};
+
+const getPendingInvitationsForUser = async (userEmail: string) => {
+  return await OrgRepository.getPendingInvitationsByEmail(userEmail.toLowerCase().trim());
+};
+
 const markInvitationEmailSent = async (invitationId: string) => {
   await OrgRepository.markInvitationEmailSent(invitationId);
 };
@@ -148,12 +215,16 @@ const OrgService = {
   getOrgMembers,
   inviteMember,
   acceptInvitation,
+  acceptInvitationById,
+  getInvitationInfo,
   cancelInvitation,
+  cancelInvitationByInvitee,
   removeMember,
   leaveOrg,
   markInvitationEmailSent,
   getProfileById,
   getPendingInvitations,
+  getPendingInvitationsForUser,
 };
 
 export default OrgService;


### PR DESCRIPTION
## 변경 개요                                                                      
                                                                                    
  초대 링크 플로우를 전면 재설계합니다.                            
  기존 `/invite/accept` 페이지는 진입 즉시 자동 수락 처리했으나,                    
  수락/거절 UI를 거치도록 변경하고 미인증 사용자 플로우를 분리했습니다.             
                                                                                    
  ## 플로우 변경                                                                    
                                                                                    
  ### 로그인된 사용자                                                               
  - 링크 클릭 → 조직명 + 수락/거절 버튼 페이지 → 수락 시 season 페이지              
                                                                                    
  ### 미인증 사용자 (이메일 링크)                                                 
  - 링크 클릭 → 회원가입/로그인 → orga 선택 페이지
  - 선택 페이지에서 "초대받은 조직" 목록 표시 → 클릭 → 수락/거절 UI                 
                                              
  ### 만료 플로우                                                                   
  - 만료된 링크 접근 → 만료 안내 페이지                                             
  - 멤버 설정 페이지에서 재초대 버튼 → 새 토큰 발급 + 이메일 재발송                 
                                                                                    
  ### 취소 플로우                                                                   
  - 수락 페이지에서 거절 클릭 → 초대 CANCELLED 처리                                 
  - 취소된 링크 접근 → 취소 안내 페이지                                             
                                                                                    
  ## 완료 조건                                                                      
                                                                                    
  - [x] `/invite/accept` 페이지에 수락/거절 버튼 UI 표시                          
  - [x] 미인증 사용자 → 로그인 후 orga 선택 페이지로 이동                           
  - [x] orga 선택 페이지에 pending 초대 조직 목록 표시                            
  - [x] 초대받은 사람이 거절 클릭 시 초대 CANCELLED 처리                            
  - [x] 만료/취소된 링크 접근 시 각각 안내 페이지 표시                            
  - [x] 멤버 설정 페이지에서 만료된 초대 재초대 가능                                
                                                                                    
  ## 주요 변경 파일                                                                 
                                                                                    
  | 파일 | 내용 |                                                                   
  |------|------|                                                                   
  | `repository.ts` | `getInvitationById`, `getPendingInvitationsByEmail` 추가 |    
  | `service.ts` | `getInvitationInfo`, `acceptInvitationById`,                     
  `cancelInvitationByInvitee`, `getPendingInvitationsForUser` 추가 |
  | `actions.ts` | 위 서비스에 대응하는 server action 4개 추가 |                    
  | `invite/accept/page.tsx` | 자동 수락 제거 → 확인 UI 렌더링으로 변경 |           
  | `InviteAcceptClient.tsx` | 수락/거절 버튼 클라이언트 컴포넌트 (신규) |          
  | `OrgSelectPageClient.tsx` | 초대받은 조직 섹션 추가 |                           
  | `MembersPageClient.tsx` | 만료 여부 기반 재초대/취소 버튼 분기 |  