### PR TITLE
fix: 다른 유저로 로그인 시 초대 링크 접근 가능한 문제 수정

### DIFF
--- a/apps/assassin/src/features/org/service.ts
+++ b/apps/assassin/src/features/org/service.ts
@@ -147,7 +147,7 @@ const getInvitationInfo = async (params: { token?: string; id?: string }, userEm
   if (invitation.status === "EXPIRED" || new Date() > invitation.expiresAt)
     throw new Error("EXPIRED");
 
-  if (params.id && userEmail && invitation.email !== userEmail.toLowerCase().trim()) {
+  if (userEmail && invitation.email !== userEmail.toLowerCase().trim()) {
     throw new Error("EMAIL_MISMATCH");
   }
 


### PR DESCRIPTION
  ## 문제
  이메일 초대 링크(`?token=xxx`)로 접근할 때, 초대받은 유저가 아닌 다른 계정으로 로그인된
  상태여도 초대 수락 UI가 노출되는 문제가 있었습니다.

  ## 원인
  `getInvitationInfo`의 이메일 불일치 체크 조건이 `params.id` 경로일 때만 동작했습니다.
  이메일 링크(`?token`)로 직접 접근하는 경우 이메일 비교를 건너뛰어 다른 유저에게도 accept
   UI가 표시됐습니다.

  ## 수정
  `params.id` 조건을 제거해 로그인 상태(`userEmail`이 존재)라면 token/id 경로 모두 이메일
  비교를 수행하도록 변경했습니다.