### PR TITLE
fix: BroadcastChannel로 탭 간 로그인/로그아웃 동기화

### DIFF
--- a/apps/assassin/src/app/login/page.tsx
+++ b/apps/assassin/src/app/login/page.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { createBrowserSupabaseClient } from "@libs/supabase/client";
+import { AUTH_BROADCAST_CHANNEL } from "@/hooks/useAuthSync";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -33,6 +34,9 @@ export default function LoginPage() {
       return;
     }
 
+    const channel = new BroadcastChannel(AUTH_BROADCAST_CHANNEL);
+    channel.postMessage({ event: "SIGNED_IN" });
+    channel.close();
     setIsLoading(false);
     router.push(next ?? "/");
   };

--- a/apps/assassin/src/components/navigation/LogoutButton.tsx
+++ b/apps/assassin/src/components/navigation/LogoutButton.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { createBrowserSupabaseClient } from "@libs/supabase/client";
+import { AUTH_BROADCAST_CHANNEL } from "@/hooks/useAuthSync";
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/common/ConfirmDialog";
 import { LogOut } from "lucide-react";
@@ -15,6 +16,9 @@ export function LogoutButton() {
     setOpen(false);
     const supabase = createBrowserSupabaseClient();
     await supabase.auth.signOut();
+    const channel = new BroadcastChannel(AUTH_BROADCAST_CHANNEL);
+    channel.postMessage({ event: "SIGNED_OUT" });
+    channel.close();
     router.push("/login");
   };
 

--- a/apps/assassin/src/hooks/useAuthSync.ts
+++ b/apps/assassin/src/hooks/useAuthSync.ts
@@ -1,0 +1,17 @@
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+export const AUTH_BROADCAST_CHANNEL = "auth";
+
+export function useAuthSync() {
+  const router = useRouter();
+
+  useEffect(() => {
+    const channel = new BroadcastChannel(AUTH_BROADCAST_CHANNEL);
+    channel.onmessage = (e: MessageEvent<{ event: string }>) => {
+      if (e.data.event === "SIGNED_OUT") router.push("/login");
+      if (e.data.event === "SIGNED_IN" && window.location.pathname === "/login") router.push("/");
+    };
+    return () => channel.close();
+  }, [router]);
+}

--- a/apps/assassin/src/libs/react-query/provider.tsx
+++ b/apps/assassin/src/libs/react-query/provider.tsx
@@ -3,6 +3,7 @@
 import { QueryClientProvider } from "@tanstack/react-query";
 import { ReactNode } from "react";
 import { getQueryClient } from "./getQueryClient";
+import { useAuthSync } from "@/hooks/useAuthSync";
 
 export default function Providers({ children }: { children: ReactNode }) {
   // NOTE: Avoid useState when initializing the query client if you don't
@@ -10,6 +11,8 @@ export default function Providers({ children }: { children: ReactNode }) {
   //       suspend because React will throw away the client on the initial
   //       render if it suspends and there is no boundary
   const queryClient = getQueryClient();
+
+  useAuthSync();
 
   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
 }


### PR DESCRIPTION
## 개요                                                                      
같은 브라우저에서 여러 탭을 열어 사용할 때, 한 탭에서 로그인/로그아웃하면 다른 탭에도 즉시 반영되도록 BroadcastChannel 기반 탭 간 인증 상태 동기화를 추가했습니다.                                                                  
                                                                                 
## 변경 사항                                                                   
  - `src/hooks/useAuthSync.ts` — BroadcastChannel 수신 훅 추가                   
    - `SIGNED_OUT` 수신 시 → `/login` 리다이렉트
    - `SIGNED_IN` 수신 시 + 현재 경로가 `/login`이면 → `/` 리다이렉트            
  - `src/libs/react-query/provider.tsx` — `useAuthSync` 훅 등록 (앱 전체에 적용) 
  - `src/components/navigation/LogoutButton.tsx` — 로그아웃 시 `SIGNED_OUT`      
  브로드캐스트                                                                   
  - `src/app/login/page.tsx` — 로그인 성공 시 `SIGNED_IN` 브로드캐스트   