### PR TITLE
fix: 전 도메인 서비스·리포지토리 orgId 검증 및 뮤테이션 캐시 키 통일

### DIFF
--- a/apps/assassin/src/app/org/[orgSlug]/@modal/(.)song/[songId]/page.tsx
+++ b/apps/assassin/src/app/org/[orgSlug]/@modal/(.)song/[songId]/page.tsx
@@ -66,7 +66,7 @@ async function SongModalContent({
   await Promise.all([
     queryClient.prefetchQuery({
       queryKey: playerKeys.bySong(orgId, songId),
-      queryFn: () => PlayerService.getPlayersBySongId(songId, userId),
+      queryFn: () => PlayerService.getPlayersBySongId(songId, orgId, userId),
     }),
     queryClient.prefetchQuery({
       queryKey: userKeys.profilesBySong(orgId, songId),

--- a/apps/assassin/src/app/org/[orgSlug]/@modal/(.)song/[songId]/page.tsx
+++ b/apps/assassin/src/app/org/[orgSlug]/@modal/(.)song/[songId]/page.tsx
@@ -70,7 +70,7 @@ async function SongModalContent({
     }),
     queryClient.prefetchQuery({
       queryKey: userKeys.profilesBySong(orgId, songId),
-      queryFn: () => UserService.getProfilesBySong(songId, userId),
+      queryFn: () => UserService.getProfilesBySong(songId, orgId, userId),
     }),
   ]);
 

--- a/apps/assassin/src/app/org/[orgSlug]/calendar/page.tsx
+++ b/apps/assassin/src/app/org/[orgSlug]/calendar/page.tsx
@@ -58,15 +58,15 @@ async function CalendarDataFetch({ params, searchParams }: CalendarPageProps) {
     events.flatMap((event) => [
       queryClient.prefetchQuery({
         queryKey: rsvpKeys.byEvent(org.id, event.id),
-        queryFn: () => getRsvpAttendeesAction(event.id),
+        queryFn: () => getRsvpAttendeesAction(event.id, org.id),
       }),
       queryClient.prefetchQuery({
         queryKey: rsvpKeys.byUser(org.id, event.id),
-        queryFn: () => getUserRsvpStatusAction(event.id),
+        queryFn: () => getUserRsvpStatusAction(event.id, org.id),
       }),
       queryClient.prefetchQuery({
         queryKey: eventSongKeys.byEvent(org.id, event.id),
-        queryFn: () => getSongsByEventAction(event.id),
+        queryFn: () => getSongsByEventAction(event.id, org.id),
       }),
     ]),
   );

--- a/apps/assassin/src/app/org/[orgSlug]/song/[songId]/page.tsx
+++ b/apps/assassin/src/app/org/[orgSlug]/song/[songId]/page.tsx
@@ -80,7 +80,7 @@ async function OrgSongPageContent({
   await Promise.all([
     queryClient.prefetchQuery({
       queryKey: playerKeys.bySong(orgId, songId),
-      queryFn: () => PlayerService.getPlayersBySongId(songId, userId),
+      queryFn: () => PlayerService.getPlayersBySongId(songId, orgId, userId),
     }),
     queryClient.prefetchQuery({
       queryKey: userKeys.profilesBySong(orgId, songId),

--- a/apps/assassin/src/app/org/[orgSlug]/song/[songId]/page.tsx
+++ b/apps/assassin/src/app/org/[orgSlug]/song/[songId]/page.tsx
@@ -84,7 +84,7 @@ async function OrgSongPageContent({
     }),
     queryClient.prefetchQuery({
       queryKey: userKeys.profilesBySong(orgId, songId),
-      queryFn: () => UserService.getProfilesBySong(songId, userId),
+      queryFn: () => UserService.getProfilesBySong(songId, orgId, userId),
     }),
   ]);
 

--- a/apps/assassin/src/app/org/create/page.tsx
+++ b/apps/assassin/src/app/org/create/page.tsx
@@ -10,25 +10,37 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 
+const SLUG_REGEX = /^[a-z0-9-]+$/;
+
 export default function CreateOrgPage() {
   const router = useRouter();
+  const [name, setName] = useState("");
+  const [slug, setSlug] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
 
+  const slugError =
+    slug && !SLUG_REGEX.test(slug) ? "소문자, 숫자, 하이픈만 사용할 수 있습니다." : null;
+
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    const formData = new FormData(e.currentTarget);
-    const name = formData.get("name") as string;
-    const slug = formData.get("slug") as string;
+
+    if (!SLUG_REGEX.test(slug)) {
+      setError("슬러그는 소문자, 숫자, 하이픈만 사용할 수 있습니다.");
+      return;
+    }
 
     setPending(true);
     setError(null);
-    try {
-      const org = await createOrgAction({ name, slug });
-      router.push(`/org/${org.slug}/season`);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "오류가 발생했습니다.");
+    const result = await createOrgAction({ name, slug });
+    if (!result.success) {
+      setError(result.error);
       setPending(false);
+    } else {
+      setName("");
+      setSlug("");
+      setPending(false);
+      router.replace(`/org/${result.slug}/season`);
     }
   }
 
@@ -59,6 +71,8 @@ export default function CreateOrgPage() {
                 required
                 maxLength={100}
                 placeholder="예: 선셋 밴드"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
                 className="bg-white dark:bg-slate-900 border-slate-200 dark:border-slate-700"
               />
             </div>
@@ -73,17 +87,22 @@ export default function CreateOrgPage() {
                 required
                 maxLength={50}
                 placeholder="예: sunset-band"
-                pattern="[a-z0-9-]+"
+                value={slug}
+                onChange={(e) => setSlug(e.target.value)}
                 className="bg-white dark:bg-slate-900 border-slate-200 dark:border-slate-700"
               />
-              <p className="text-xs text-slate-500 dark:text-slate-400">
-                소문자, 숫자, 하이픈만 허용 · 생성 후 변경 불가
-              </p>
+              {slugError ? (
+                <p className="text-xs text-red-500">{slugError}</p>
+              ) : (
+                <p className="text-xs text-slate-500 dark:text-slate-400">
+                  소문자, 숫자, 하이픈만 허용 · 생성 후 변경 불가
+                </p>
+              )}
             </div>
             {error && <p className="text-sm text-red-500">{error}</p>}
             <Button
               type="submit"
-              disabled={pending}
+              disabled={pending || !!slugError}
               className="w-full bg-blue-500 hover:bg-blue-600 text-white"
             >
               {pending ? (

--- a/apps/assassin/src/components/calendar/CalendarPageClient.tsx
+++ b/apps/assassin/src/components/calendar/CalendarPageClient.tsx
@@ -19,7 +19,6 @@ import { RsvpButton } from "@/components/calendar/RsvpButton";
 import { RsvpList } from "@/components/calendar/RsvpList";
 import { EventSongList } from "@/components/calendar/EventSongList";
 import { EventSongAddForm } from "@/components/calendar/EventSongAddForm";
-import { useRealtimeSongSync } from "@/features/song/hooks/useRealtimeSongSync";
 import { useRealtimeSeasonSync } from "@/features/season/hooks/useRealtimeSeasonSync";
 
 type DialogState =
@@ -44,7 +43,6 @@ export function CalendarPageClient() {
   const month = urlDate.getMonth() + 1;
 
   useRealtimeCalendarEventSync();
-  useRealtimeSongSync();
   useRealtimeSeasonSync();
 
   const { getEventsForDay } = useCalendarEventLogic(year, month);

--- a/apps/assassin/src/components/calendar/CalendarPageClient.tsx
+++ b/apps/assassin/src/components/calendar/CalendarPageClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState, startTransition } from "react";
+import { useCallback, useEffect, useMemo, useState, startTransition } from "react";
 import { ko } from "date-fns/locale";
 import { useRouter, useSearchParams, usePathname } from "next/navigation";
 import { CalendarIcon, MapPin, Clock, Plus, Pencil, Trash2 } from "lucide-react";
@@ -62,22 +62,25 @@ export function CalendarPageClient() {
     });
   }, [urlDate]);
 
-  const updateUrlParamQuietly = (date: Date) => {
-    const y = date.getFullYear();
-    const m = String(date.getMonth() + 1).padStart(2, "0");
-    const d = String(date.getDate()).padStart(2, "0");
+  const updateUrlParamQuietly = useCallback(
+    (date: Date) => {
+      const y = date.getFullYear();
+      const m = String(date.getMonth() + 1).padStart(2, "0");
+      const d = String(date.getDate()).padStart(2, "0");
 
-    const params = new URLSearchParams(searchParams?.toString() || "");
-    params.set("date", `${y}-${m}-${d}`);
-    window.history.replaceState(null, "", `${pathname}?${params.toString()}`);
-  };
+      const params = new URLSearchParams(searchParams?.toString() || "");
+      params.set("date", `${y}-${m}-${d}`);
+      window.history.replaceState(null, "", `${pathname}?${params.toString()}`);
+    },
+    [searchParams, pathname],
+  );
 
-  // 최초 로드 시 ?date= 파라미터가 없으면 url에 강제로 넣고 시작
+  // ?date= 파라미터가 없으면 url에 강제로 넣음
   useEffect(() => {
     if (!searchParams?.has("date")) {
       updateUrlParamQuietly(new Date());
     }
-  }, []);
+  }, [searchParams, updateUrlParamQuietly]);
 
   const handleMonthChange = (newMonth: Date) => {
     setCalendarMonth(newMonth);

--- a/apps/assassin/src/components/navigation/AppNav.tsx
+++ b/apps/assassin/src/components/navigation/AppNav.tsx
@@ -27,7 +27,7 @@ export function AppNav() {
       </div>
 
       <div className="hidden md:flex items-center gap-1 pb-1 sm:pb-0">
-        <Button
+        {/* <Button
           variant="ghost"
           size="sm"
           asChild
@@ -41,7 +41,7 @@ export function AppNav() {
             <Youtube className="h-4 w-4" />
             <span className="hidden sm:inline ml-2">YouTube</span>
           </a>
-        </Button>
+        </Button> */}
         <ProfileButton />
         <LogoutButton />
       </div>

--- a/apps/assassin/src/components/navigation/NavOverflowMenu.tsx
+++ b/apps/assassin/src/components/navigation/NavOverflowMenu.tsx
@@ -42,7 +42,7 @@ export function NavOverflowMenu() {
           className="w-52 p-2 bg-white/95 dark:bg-slate-900/95 backdrop-blur-sm border-slate-200 dark:border-slate-700 shadow-lg"
         >
           <div className="flex flex-col gap-1">
-            <a
+            {/* <a
               href="https://youtube.com/@dnab-dnab?si=iX2ulzqGQYl_4Xm9"
               target="_blank"
               rel="noopener noreferrer"
@@ -51,7 +51,7 @@ export function NavOverflowMenu() {
             >
               <Youtube className="mr-2 h-4 w-4" />
               YouTube
-            </a>
+            </a> */}
 
             <Link
               href="/profile"

--- a/apps/assassin/src/components/season/SeasonBoard.tsx
+++ b/apps/assassin/src/components/season/SeasonBoard.tsx
@@ -1,7 +1,7 @@
 import { Season } from "@features/season/schema";
 import { SeasonColumn } from "./SeasonColumn";
 import { AddSeasonCard } from "./AddSeasonCard";
-import { useRealtimeSongSync } from "@/features/song/hooks/useRealtimeSongSync";
+import { useRealtimeSongsBySeasonSync } from "@/features/song/hooks/useRealtimeSongSync";
 import { DndContext, DragOverlay, closestCenter } from "@dnd-kit/core";
 import { useSongDragDrop } from "@/features/song/hooks/useSongDragDrop";
 import { SongItem } from "../song/SongItem";
@@ -14,7 +14,7 @@ interface SeasonBoardProps {
 export function SeasonBoard({ seasons, canCreate = false }: SeasonBoardProps) {
   const sortedSeasons = [...seasons].sort((a, b) => Number(a.sortOrder) - Number(b.sortOrder));
   const nextSortOrder = sortedSeasons.length;
-  useRealtimeSongSync();
+  useRealtimeSongsBySeasonSync(sortedSeasons.map((season) => season.id));
   const { sensors, activeSong, handleDragStart, handleDragCancel, handleDragEnd } = useSongDragDrop(
     { seasonIds: sortedSeasons.map((season) => season.id) },
   );

--- a/apps/assassin/src/components/season/SeasonColumn.tsx
+++ b/apps/assassin/src/components/season/SeasonColumn.tsx
@@ -131,7 +131,7 @@ export function SeasonColumn({ season, variant = "grid" }: SeasonColumnProps) {
               ) : (
                 <div className="flex items-center gap-2 group">
                   <h3
-                    className={`font-semibold text-base truncate ${
+                    className={`font-semibold text-base truncate w-0 flex-1 ${
                       isArchived
                         ? "text-slate-500 dark:text-slate-400"
                         : "text-slate-900 dark:text-slate-50"

--- a/apps/assassin/src/components/season/SeasonColumn.tsx
+++ b/apps/assassin/src/components/season/SeasonColumn.tsx
@@ -6,7 +6,7 @@ import { Season } from "@features/season/schema";
 import type { Song } from "@features/song/schema";
 import { useUpdateSeason } from "@features/season/mutations/useUpdateSeason";
 import { useDeleteSeason } from "@features/season/mutations/useDeleteSeason";
-import { useOrgRole } from "@libs/org/OrgProvider";
+import { useOrgRole } from "@/components/org/OrgProvider";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Archive, Music, Plus, Pencil, Check, X, ArchiveRestore, Trash2 } from "lucide-react";
@@ -240,7 +240,7 @@ export function SeasonColumn({ season, variant = "grid" }: SeasonColumnProps) {
         title="시즌 삭제"
         description={`"${season.name}" 시즌을 삭제하면 되돌릴 수 없습니다.`}
         confirmLabel="삭제"
-        onConfirm={() => deleteSeason.mutate(season.id)}
+        onConfirm={() => deleteSeason.mutate({ id: season.id })}
         isConfirming={deleteSeason.isPending}
         icon={<Trash2 className="h-4 w-4" />}
       />

--- a/apps/assassin/src/components/season/SeasonPageClient.tsx
+++ b/apps/assassin/src/components/season/SeasonPageClient.tsx
@@ -7,7 +7,6 @@ import { SeasonBoard } from "./SeasonBoard";
 import { AppNav } from "@/components/navigation/AppNav";
 import { useSeasons } from "@/features/season/queries/useSeasons";
 import { useRealtimeSeasonSync } from "@/features/season/hooks/useRealtimeSeasonSync";
-import { useRealtimeSongSync } from "@/features/song/hooks/useRealtimeSongSync";
 import { useOrgRole } from "../org/OrgProvider";
 
 export function SeasonPageClient() {
@@ -16,7 +15,6 @@ export function SeasonPageClient() {
   const seasons = seasonsQuery.data ?? [];
   const role = useOrgRole();
   useRealtimeSeasonSync();
-  useRealtimeSongSync();
 
   const activeSeasons = seasons.filter((s) => !s.isArchived);
   const archivedSeasons = seasons.filter((s) => s.isArchived);

--- a/apps/assassin/src/components/song/LikeButton.tsx
+++ b/apps/assassin/src/components/song/LikeButton.tsx
@@ -33,7 +33,7 @@ export function LikeButton({ song }: LikeButtonProps) {
       aria-label={liked ? "좋아요 취소" : "좋아요"}
     >
       <Heart className={cn("h-4 w-4 transition-all", liked && "fill-current")} />
-      <span className="tabular-nums">{song.likeCount}</span>
+      <span className="tabular-nums">{Math.max(0, song.likeCount)}</span>
     </Button>
   );
 }

--- a/apps/assassin/src/components/song/SongDetailModal.tsx
+++ b/apps/assassin/src/components/song/SongDetailModal.tsx
@@ -24,7 +24,7 @@ export function SongDetailModal({ songId, open, onOpenChange }: SongDetailModalP
   const params = useParams<{ orgSlug?: string }>();
 
   const song = useSong(songId).data;
-  useRealtimeSongSync();
+  useRealtimeSongSync(songId);
 
   if (!song) {
     return null;

--- a/apps/assassin/src/features/comment/actions.ts
+++ b/apps/assassin/src/features/comment/actions.ts
@@ -5,42 +5,50 @@ import { getCurrentUser } from "@libs/supabase/auth";
 import CommentService from "./service";
 import { CommentUpdatePayload } from "./schema";
 
-export const getCommentAction = async (id: string) => {
+export const getCommentAction = async (id: string, orgId: string) => {
   const user = await getCurrentUser();
-  return await CommentService.getCommentById(id, user.id);
+  return await CommentService.getCommentById(id, user.id, orgId);
 };
 
-export const getCommentsBySongAction = async (songId: string) => {
+export const getCommentsBySongAction = async (songId: string, orgId: string) => {
   const user = await getCurrentUser();
-  return await CommentService.getCommentsBySongId(songId, user.id);
+  return await CommentService.getCommentsBySongId(songId, user.id, orgId);
 };
 
 export const getCommentsBySongPaginatedAction = async (
   songId: string,
+  orgId: string,
   limit: number,
   cursor?: string,
 ) => {
   const user = await getCurrentUser();
-  return await CommentService.getCommentsBySongIdPaginated(songId, limit, user.id, cursor);
+  return await CommentService.getCommentsBySongIdPaginated(songId, limit, user.id, orgId, cursor);
 };
 
-export const createCommentAction = async (data: { songId: string; content: string }) => {
+export const createCommentAction = async (
+  orgId: string,
+  data: { songId: string; content: string },
+) => {
   const user = await getCurrentUser();
-  const result = await CommentService.createComment({ ...data, userId: user.id }, user.id);
+  const result = await CommentService.createComment({ ...data, userId: user.id }, user.id, orgId);
   revalidateSongDetail(result.songId);
   return result;
 };
 
-export const updateCommentAction = async (id: string, data: CommentUpdatePayload) => {
+export const updateCommentAction = async (
+  id: string,
+  orgId: string,
+  data: CommentUpdatePayload,
+) => {
   const user = await getCurrentUser();
-  const result = await CommentService.updateComment(id, data, user.id);
+  const result = await CommentService.updateComment(id, data, user.id, orgId);
   revalidateSongDetail(result.songId);
   return result;
 };
 
-export const deleteCommentAction = async (id: string) => {
+export const deleteCommentAction = async (id: string, orgId: string) => {
   const user = await getCurrentUser();
-  const existing = await CommentService.getCommentById(id, user.id);
-  await CommentService.deleteComment(id, user.id);
+  const existing = await CommentService.getCommentById(id, user.id, orgId);
+  await CommentService.deleteComment(id, user.id, orgId);
   revalidateSongDetail(existing.songId);
 };

--- a/apps/assassin/src/features/comment/mutations/useCreateComment.ts
+++ b/apps/assassin/src/features/comment/mutations/useCreateComment.ts
@@ -9,7 +9,7 @@ export const useCreateComment = () => {
   const orgId = useOrgId();
 
   return useMutation({
-    mutationFn: (data: CommentFormData) => createCommentAction(data),
+    mutationFn: (data: CommentFormData) => createCommentAction(orgId, data),
     onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: commentKeys.bySong(orgId, data.songId) });
     },

--- a/apps/assassin/src/features/comment/mutations/useDeleteComment.ts
+++ b/apps/assassin/src/features/comment/mutations/useDeleteComment.ts
@@ -8,7 +8,8 @@ export const useDeleteComment = () => {
   const orgId = useOrgId();
 
   return useMutation({
-    mutationFn: (variables: { id: string; songId: string }) => deleteCommentAction(variables.id),
+    mutationFn: (variables: { id: string; songId: string }) =>
+      deleteCommentAction(variables.id, orgId),
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: commentKeys.bySong(orgId, variables.songId) });
     },

--- a/apps/assassin/src/features/comment/mutations/useUpdateComment.ts
+++ b/apps/assassin/src/features/comment/mutations/useUpdateComment.ts
@@ -10,7 +10,7 @@ export const useUpdateComment = () => {
 
   return useMutation({
     mutationFn: ({ id, data }: { id: string; data: CommentUpdatePayload }) =>
-      updateCommentAction(id, data),
+      updateCommentAction(id, orgId, data),
     onSuccess: (data) => {
       if (!data) return;
 

--- a/apps/assassin/src/features/comment/queries/useCommentsBySong.ts
+++ b/apps/assassin/src/features/comment/queries/useCommentsBySong.ts
@@ -8,6 +8,7 @@ export const useCommentsBySong = (songId: string) => {
 
   return useSuspenseQuery({
     queryKey: commentKeys.bySong(orgId, songId),
-    queryFn: () => getCommentsBySongAction(songId),
+    queryFn: () => getCommentsBySongAction(songId, orgId),
+    staleTime: 1000 * 60,
   });
 };

--- a/apps/assassin/src/features/comment/queries/useInfiniteCommentsBySong.ts
+++ b/apps/assassin/src/features/comment/queries/useInfiniteCommentsBySong.ts
@@ -11,8 +11,9 @@ export const useInfiniteCommentsBySong = (songId: string) => {
   return useInfiniteQuery({
     queryKey: commentKeys.bySong(orgId, songId),
     queryFn: ({ pageParam }) =>
-      getCommentsBySongPaginatedAction(songId, COMMENTS_PER_PAGE, pageParam),
+      getCommentsBySongPaginatedAction(songId, orgId, COMMENTS_PER_PAGE, pageParam),
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+    staleTime: 1000 * 60,
   });
 };

--- a/apps/assassin/src/features/comment/repository.ts
+++ b/apps/assassin/src/features/comment/repository.ts
@@ -2,99 +2,79 @@ import { prisma } from "@libs/prisma/client";
 import { CommentPayload, CommentUpdatePayload } from "./schema";
 import { TransactionClient } from "@libs/prisma/types";
 
-async function getAllComments() {
-  const comments = await prisma.comment.findMany({
-    where: { deletedAt: null },
-    orderBy: { createdAt: "desc" },
+async function getCommentById(id: string, orgId: string) {
+  return prisma.comment.findFirst({
+    where: { id, deletedAt: null, song: { season: { orgId } } },
     include: { profile: true },
   });
-  return comments;
 }
 
-async function getCommentById(id: string) {
-  const comment = await prisma.comment.findUnique({
-    where: {
-      id,
-      deletedAt: null,
-    },
+async function getCommentsBySongId(songId: string, orgId: string) {
+  return prisma.comment.findMany({
+    where: { songId, deletedAt: null, song: { season: { orgId } } },
     include: { profile: true },
   });
-  return comment;
 }
 
-async function getCommentsBySongId(songId: string) {
-  const comments = await prisma.comment.findMany({
-    where: {
-      songId: songId,
-      deletedAt: null,
-    },
+async function createComment(input: CommentPayload, orgId: string) {
+  const song = await prisma.song.findFirst({
+    where: { id: input.songId, season: { orgId }, deletedAt: null },
+    select: { id: true },
+  });
+  if (!song) throw new Error("Song not found in org");
+
+  return prisma.comment.create({
+    data: { content: input.content, userId: input.userId, songId: input.songId },
     include: { profile: true },
   });
-  return comments;
 }
 
-async function createComment(input: CommentPayload) {
-  const comment = await prisma.comment.create({
-    data: {
-      content: input.content,
-      userId: input.userId,
-      songId: input.songId,
-    },
-    include: { profile: true },
+async function updateComment(id: string, orgId: string, input: CommentUpdatePayload) {
+  const existing = await prisma.comment.findFirst({
+    where: { id, deletedAt: null, song: { season: { orgId } } },
+    select: { id: true },
   });
-  return comment;
-}
+  if (!existing) throw new Error("Comment not found in org");
 
-async function updateComment(id: string, input: CommentUpdatePayload) {
-  const comment = await prisma.comment.update({
+  return prisma.comment.update({
     where: { id },
-    data: {
-      content: input.content,
-      songId: input.songId,
-    },
+    data: { content: input.content, songId: input.songId },
     include: { profile: true },
   });
-  return comment;
 }
 
-async function deleteComment(id: string, tx?: TransactionClient) {
+async function deleteComment(id: string, orgId: string, tx?: TransactionClient) {
   const prismaClient = tx || prisma;
-  await prismaClient.comment.update({
-    where: { id },
+  await prismaClient.comment.updateMany({
+    where: { id, deletedAt: null, song: { season: { orgId } } },
     data: { deletedAt: new Date() },
   });
 }
 
-async function getCommentsBySongIdPaginated(songId: string, limit: number, cursor?: string) {
-  return await prisma.comment.findMany({
-    where: {
-      songId,
-      deletedAt: null,
-    },
+async function getCommentsBySongIdPaginated(
+  songId: string,
+  orgId: string,
+  limit: number,
+  cursor?: string,
+) {
+  return prisma.comment.findMany({
+    where: { songId, deletedAt: null, song: { season: { orgId } } },
     orderBy: { createdAt: "desc" },
     include: { profile: true },
-    // 1개 더 조회해서 다음 페이지 존재 여부를 서비스에서 판단할 수 있게 함
     take: limit + 1,
-    ...(cursor
-      ? {
-          // cursor 항목은 이전 페이지 마지막이므로 건너뜀
-          cursor: { id: cursor },
-          skip: 1,
-        }
-      : {}),
+    ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
   });
 }
 
-async function deleteCommentsBySongId(songId: string, tx?: TransactionClient) {
+async function deleteCommentsBySongId(songId: string, orgId: string, tx?: TransactionClient) {
   const prismaClient = tx || prisma;
   await prismaClient.comment.updateMany({
-    where: { songId: songId },
+    where: { songId, song: { season: { orgId } } },
     data: { deletedAt: new Date() },
   });
 }
 
 const CommentRepository = {
-  getAllComments,
   getCommentById,
   getCommentsBySongId,
   getCommentsBySongIdPaginated,

--- a/apps/assassin/src/features/comment/service.ts
+++ b/apps/assassin/src/features/comment/service.ts
@@ -1,5 +1,5 @@
-import SongService from "@features/song/service";
-import OrgRepository from "@features/org/repository";
+import { assertOrgMember } from "@features/org/service";
+import SongRepository from "@features/song/repository";
 import CommentRepository from "./repository";
 import {
   Comment,
@@ -9,59 +9,52 @@ import {
   updateCommentSchema,
 } from "./schema";
 
-const assertCommentExists = async (commentId: string): Promise<void> => {
-  const comment = await CommentRepository.getCommentById(commentId);
-
+const assertCommentExists = async (commentId: string, orgId: string): Promise<void> => {
+  const comment = await CommentRepository.getCommentById(commentId, orgId);
   const parsed = commentSchema.safeParse(comment);
-
   if (!parsed.success) {
     throw new Error(`Comment with ID ${commentId} does not exist.`);
   }
 };
 
-const createComment = async (comment: CommentPayload, userId: string): Promise<Comment> => {
+const createComment = async (
+  comment: CommentPayload,
+  userId: string,
+  orgId: string,
+): Promise<Comment> => {
   if (comment.userId !== userId) {
     throw new Error("Unauthorized: invalid comment author");
   }
-
-  await SongService.assertSongAccess(comment.songId, userId);
-
-  const result = await CommentRepository.createComment(comment);
-
+  await assertOrgMember(userId, orgId);
+  const result = await CommentRepository.createComment(comment, orgId);
   const parsed = commentSchema.safeParse(result);
-
   if (!parsed.success) {
     throw new Error("Invalid comment response from DB");
   }
-
   return parsed.data;
 };
 
-const getCommentById = async (id: string, userId: string): Promise<Comment> => {
-  const comment = await CommentRepository.getCommentById(id);
-
+const getCommentById = async (id: string, userId: string, orgId: string): Promise<Comment> => {
+  await assertOrgMember(userId, orgId);
+  const comment = await CommentRepository.getCommentById(id, orgId);
   const parsed = commentSchema.safeParse(comment);
-
   if (!parsed.success) {
     throw new Error("Invalid comment response from DB");
   }
-
-  await SongService.assertSongAccess(parsed.data.songId, userId);
-
   return parsed.data;
 };
 
-const getCommentsBySongId = async (songId: string, userId: string): Promise<Array<Comment>> => {
-  await SongService.assertSongAccess(songId, userId);
-
-  const comments = await CommentRepository.getCommentsBySongId(songId);
-
+const getCommentsBySongId = async (
+  songId: string,
+  userId: string,
+  orgId: string,
+): Promise<Array<Comment>> => {
+  await assertOrgMember(userId, orgId);
+  const comments = await CommentRepository.getCommentsBySongId(songId, orgId);
   const parsed = commentSchema.array().safeParse(comments);
-
   if (!parsed.success) {
     throw new Error("Invalid comment responses from DB");
   }
-
   return parsed.data;
 };
 
@@ -69,75 +62,64 @@ const getCommentsBySongIdPaginated = async (
   songId: string,
   limit: number,
   userId: string,
+  orgId: string,
   cursor?: string,
 ): Promise<{ comments: Comment[]; nextCursor: string | null }> => {
-  await SongService.assertSongAccess(songId, userId);
-
-  const result = await CommentRepository.getCommentsBySongIdPaginated(songId, limit, cursor);
-
+  await assertOrgMember(userId, orgId);
+  const result = await CommentRepository.getCommentsBySongIdPaginated(songId, orgId, limit, cursor);
   const parsed = commentSchema.array().safeParse(result);
-
   if (!parsed.success) {
     throw new Error("Invalid paginated comments response from DB");
   }
-
   const hasMore = parsed.data.length > limit;
-  // 초과 1개를 잘라내고 실제 limit 개수만 반환
   const comments = hasMore ? parsed.data.slice(0, limit) : parsed.data;
   const nextCursor = hasMore ? comments[comments.length - 1].id : null;
-
   return { comments, nextCursor };
 };
 
-const updateComment = async (id: string, comment: CommentUpdatePayload, userId: string) => {
-  const existed = await getCommentById(id, userId);
+const updateComment = async (
+  id: string,
+  comment: CommentUpdatePayload,
+  userId: string,
+  orgId: string,
+) => {
+  await assertOrgMember(userId, orgId);
 
-  if (existed.userId !== userId) {
+  const existed = await CommentRepository.getCommentById(id, orgId);
+  const parsedExisted = commentSchema.safeParse(existed);
+  if (!parsedExisted.success) throw new Error("Comment not found");
+
+  if (parsedExisted.data.userId !== userId) {
     throw new Error("Unauthorized: you can only edit your own comments");
   }
 
   const parsedInput = updateCommentSchema.safeParse(comment);
+  if (!parsedInput.success) throw new Error("Invalid comment input");
 
-  if (!parsedInput.success) {
-    throw new Error("Invalid comment input");
+  if (parsedInput.data.songId && parsedInput.data.songId !== parsedExisted.data.songId) {
+    const targetSong = await SongRepository.getSongByIdInOrg(parsedInput.data.songId, orgId);
+    if (!targetSong) throw new Error("Cross-org comment move is not allowed");
   }
 
-  const sourceOrgId = await OrgRepository.getOrgIdBySongId(existed.songId);
-  if (!sourceOrgId) {
-    throw new Error(`Song with ID ${existed.songId} does not exist.`);
-  }
-
-  const targetSongId = parsedInput.data.songId ?? existed.songId;
-  const targetOrgId =
-    targetSongId === existed.songId
-      ? sourceOrgId
-      : await SongService.assertSongAccess(targetSongId, userId);
-
-  if (targetOrgId !== sourceOrgId) {
-    throw new Error("Cross-org comment move is not allowed");
-  }
-
-  const newCommentData: Comment = { ...existed, ...parsedInput.data };
-
-  const updatedComment = await CommentRepository.updateComment(id, newCommentData);
-
+  const newCommentData: Comment = { ...parsedExisted.data, ...parsedInput.data };
+  const updatedComment = await CommentRepository.updateComment(id, orgId, newCommentData);
   const parsed = commentSchema.safeParse(updatedComment);
-
-  if (!parsed.success) {
-    throw new Error("Invalid comment response from DB");
-  }
-
+  if (!parsed.success) throw new Error("Invalid comment response from DB");
   return parsed.data;
 };
 
-const deleteComment = async (id: string, userId: string): Promise<void> => {
-  const comment = await getCommentById(id, userId);
+const deleteComment = async (id: string, userId: string, orgId: string): Promise<void> => {
+  await assertOrgMember(userId, orgId);
 
-  if (comment.userId !== userId) {
+  const comment = await CommentRepository.getCommentById(id, orgId);
+  const parsed = commentSchema.safeParse(comment);
+  if (!parsed.success) throw new Error("Comment not found");
+
+  if (parsed.data.userId !== userId) {
     throw new Error("Unauthorized: you can only delete your own comments");
   }
 
-  await CommentRepository.deleteComment(id);
+  await CommentRepository.deleteComment(id, orgId);
 };
 
 const CommentService = {

--- a/apps/assassin/src/features/eventSong/actions.ts
+++ b/apps/assassin/src/features/eventSong/actions.ts
@@ -4,17 +4,17 @@ import { getCurrentUser } from "@libs/supabase/auth";
 import EventSongService from "./service";
 import { CreateEventSongPayload } from "./schema";
 
-export const getSongsByEventAction = async (eventId: string) => {
+export const getSongsByEventAction = async (eventId: string, orgId: string) => {
   const user = await getCurrentUser();
-  return EventSongService.getSongsByEvent(eventId, user.id);
+  return EventSongService.getSongsByEvent(eventId, orgId, user.id);
 };
 
-export const addSongToEventAction = async (data: CreateEventSongPayload) => {
+export const addSongToEventAction = async (orgId: string, data: CreateEventSongPayload) => {
   const user = await getCurrentUser();
-  return EventSongService.addSongToEvent(data, user.id);
+  return EventSongService.addSongToEvent(data, orgId, user.id);
 };
 
-export const removeEventSongAction = async (id: string) => {
+export const removeEventSongAction = async (id: string, orgId: string) => {
   const user = await getCurrentUser();
-  await EventSongService.removeSongFromEvent(id, user.id);
+  await EventSongService.removeSongFromEvent(id, orgId, user.id);
 };

--- a/apps/assassin/src/features/eventSong/hooks/useRealtimeEventSongSync.ts
+++ b/apps/assassin/src/features/eventSong/hooks/useRealtimeEventSongSync.ts
@@ -16,7 +16,7 @@ export const useRealtimeEventSongSync = (eventId: string) => {
   const supabase = useMemo(() => createBrowserSupabaseClient(), []);
 
   useEffect(() => {
-    const channel = supabase
+    const eventSongChannel = supabase
       .channel(`realtime:calendar_event_song:${eventId}`)
       .on(
         "postgres_changes",
@@ -35,8 +35,16 @@ export const useRealtimeEventSongSync = (eventId: string) => {
       )
       .subscribe();
 
+    const songChannel = supabase
+      .channel(`realtime:song:event-song:${orgId}:${eventId}`)
+      .on("postgres_changes", { event: "*", schema: "public", table: "song" }, () => {
+        queryClient.invalidateQueries({ queryKey: eventSongKeys.byEvent(orgId, eventId) });
+      })
+      .subscribe();
+
     return () => {
-      supabase.removeChannel(channel);
+      supabase.removeChannel(eventSongChannel);
+      supabase.removeChannel(songChannel);
     };
   }, [orgId, queryClient, eventId, supabase]);
 };

--- a/apps/assassin/src/features/eventSong/hooks/useRealtimeEventSongSync.ts
+++ b/apps/assassin/src/features/eventSong/hooks/useRealtimeEventSongSync.ts
@@ -26,12 +26,6 @@ export const useRealtimeEventSongSync = (eventId: string) => {
           const prevRow = payload.old as EventSongRow | undefined;
           const affectedEventId = nextRow?.eventId ?? prevRow?.eventId;
 
-          console.log("[Realtime Sync] Received event song change:", {
-            eventType: payload.eventType,
-            nextRow,
-            prevRow,
-          });
-
           // affectedEventId가 undefined인 경우는 REPLICA IDENTITY FULL 미설정으로 인해
           // DELETE payload에 eventId가 없는 것 — 어느 이벤트인지 모르므로 일단 invalidate
           if (affectedEventId !== undefined && affectedEventId !== eventId) return;

--- a/apps/assassin/src/features/eventSong/mutations/useAddEventSong.ts
+++ b/apps/assassin/src/features/eventSong/mutations/useAddEventSong.ts
@@ -9,7 +9,7 @@ export const useAddEventSong = () => {
   const orgId = useOrgId();
 
   return useMutation({
-    mutationFn: (data: CreateEventSongPayload) => addSongToEventAction(data),
+    mutationFn: (data: CreateEventSongPayload) => addSongToEventAction(orgId, data),
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({ queryKey: eventSongKeys.byEvent(orgId, variables.eventId) });
     },

--- a/apps/assassin/src/features/eventSong/mutations/useRemoveEventSong.ts
+++ b/apps/assassin/src/features/eventSong/mutations/useRemoveEventSong.ts
@@ -8,7 +8,7 @@ export const useRemoveEventSong = (eventId: string) => {
   const orgId = useOrgId();
 
   return useMutation({
-    mutationFn: (id: string) => removeEventSongAction(id),
+    mutationFn: (id: string) => removeEventSongAction(id, orgId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: eventSongKeys.byEvent(orgId, eventId) });
     },

--- a/apps/assassin/src/features/eventSong/queries/useSongsByEvent.ts
+++ b/apps/assassin/src/features/eventSong/queries/useSongsByEvent.ts
@@ -8,7 +8,7 @@ export const useSongsByEvent = (eventId: string) => {
 
   return useQuery({
     queryKey: eventSongKeys.byEvent(orgId, eventId),
-    queryFn: () => getSongsByEventAction(eventId),
+    queryFn: () => getSongsByEventAction(eventId, orgId),
     staleTime: 1000 * 60,
   });
 };

--- a/apps/assassin/src/features/eventSong/repository.ts
+++ b/apps/assassin/src/features/eventSong/repository.ts
@@ -1,37 +1,41 @@
 import { prisma } from "@libs/prisma/client";
 import { CreateEventSongPayload } from "./schema";
 
-async function getSongsByEventId(eventId: string) {
+async function getSongsByEventId(eventId: string, orgId: string) {
   return prisma.calendarEventSong.findMany({
-    where: { eventId },
+    where: { eventId, event: { orgId } },
     include: { song: { select: { id: true, name: true, artist: true } } },
     orderBy: { createdAt: "asc" },
   });
 }
 
-async function getEventIdByEventSongId(id: string): Promise<string | null> {
-  const eventSong = await prisma.calendarEventSong.findFirst({
-    where: { id },
-    select: { eventId: true },
+async function addSongToEvent(data: CreateEventSongPayload, orgId: string) {
+  const event = await prisma.calendarEvent.findFirst({
+    where: { id: data.eventId, orgId },
+    select: { id: true },
   });
+  if (!event) throw new Error("Event not found in org");
 
-  return eventSong?.eventId ?? null;
-}
+  const song = await prisma.song.findFirst({
+    where: { id: data.songId, season: { orgId }, deletedAt: null },
+    select: { id: true },
+  });
+  if (!song) throw new Error("Song not found in org");
 
-async function addSongToEvent(data: CreateEventSongPayload) {
   return prisma.calendarEventSong.create({
     data: { eventId: data.eventId, songId: data.songId },
     include: { song: { select: { id: true, name: true, artist: true } } },
   });
 }
 
-async function removeSongFromEvent(id: string) {
-  return prisma.calendarEventSong.delete({ where: { id } });
+async function removeSongFromEvent(id: string, orgId: string) {
+  return prisma.calendarEventSong.deleteMany({
+    where: { id, event: { orgId } },
+  });
 }
 
 const EventSongRepository = {
   getSongsByEventId,
-  getEventIdByEventSongId,
   addSongToEvent,
   removeSongFromEvent,
 };

--- a/apps/assassin/src/features/eventSong/service.ts
+++ b/apps/assassin/src/features/eventSong/service.ts
@@ -1,20 +1,14 @@
 import { assertOrgMember } from "@features/org/service";
-import OrgRepository from "@features/org/repository";
 import { CreateEventSongPayload, EventSong, eventSongSchema } from "./schema";
 import EventSongRepository from "./repository";
-import { z } from "zod";
 
-const getOrgIdByEvent = async (eventId: string): Promise<string> => {
-  const orgId = await OrgRepository.getOrgIdByEvent(eventId);
-  const parsedOrgId = z.uuid().safeParse(orgId);
-  if (!parsedOrgId.success) throw new Error("CalendarEvent not found");
-  return parsedOrgId.data;
-};
-
-const getSongsByEvent = async (eventId: string, userId: string): Promise<EventSong[]> => {
-  const orgId = await getOrgIdByEvent(eventId);
+const getSongsByEvent = async (
+  eventId: string,
+  orgId: string,
+  userId: string,
+): Promise<EventSong[]> => {
   await assertOrgMember(userId, orgId);
-  const results = await EventSongRepository.getSongsByEventId(eventId);
+  const results = await EventSongRepository.getSongsByEventId(eventId, orgId);
   const parsed = eventSongSchema.array().safeParse(results);
   if (!parsed.success) {
     throw new Error("Invalid event song responses from DB");
@@ -22,19 +16,13 @@ const getSongsByEvent = async (eventId: string, userId: string): Promise<EventSo
   return parsed.data;
 };
 
-const addSongToEvent = async (data: CreateEventSongPayload, userId: string): Promise<EventSong> => {
-  const orgId = await getOrgIdByEvent(data.eventId);
+const addSongToEvent = async (
+  data: CreateEventSongPayload,
+  orgId: string,
+  userId: string,
+): Promise<EventSong> => {
   await assertOrgMember(userId, orgId);
-
-  const songOrgId = await OrgRepository.getOrgIdBySongId(data.songId);
-  if (!songOrgId) {
-    throw new Error(`Song with ID ${data.songId} does not exist.`);
-  }
-  if (songOrgId !== orgId) {
-    throw new Error("Cross-org event-song link is not allowed");
-  }
-
-  const result = await EventSongRepository.addSongToEvent(data);
+  const result = await EventSongRepository.addSongToEvent(data, orgId);
   const parsed = eventSongSchema.safeParse(result);
   if (!parsed.success) {
     throw new Error("Invalid event song response from DB");
@@ -42,14 +30,9 @@ const addSongToEvent = async (data: CreateEventSongPayload, userId: string): Pro
   return parsed.data;
 };
 
-const removeSongFromEvent = async (id: string, userId: string): Promise<void> => {
-  const eventId = await EventSongRepository.getEventIdByEventSongId(id);
-  const parsedEventId = z.uuid().safeParse(eventId);
-  if (!parsedEventId.success) throw new Error("EventSong not found");
-
-  const orgId = await getOrgIdByEvent(parsedEventId.data);
+const removeSongFromEvent = async (id: string, orgId: string, userId: string): Promise<void> => {
   await assertOrgMember(userId, orgId);
-  await EventSongRepository.removeSongFromEvent(id);
+  await EventSongRepository.removeSongFromEvent(id, orgId);
 };
 
 const EventSongService = {

--- a/apps/assassin/src/features/org/actions.ts
+++ b/apps/assassin/src/features/org/actions.ts
@@ -19,9 +19,16 @@ async function getCurrentUserId(): Promise<string> {
   return user.id;
 }
 
-export const createOrgAction = async (input: CreateOrgPayload) => {
-  const userId = await getCurrentUserId();
-  return await OrgService.createOrg(userId, input);
+export const createOrgAction = async (
+  input: CreateOrgPayload,
+): Promise<{ success: true; slug: string } | { success: false; error: string }> => {
+  try {
+    const userId = await getCurrentUserId();
+    const org = await OrgService.createOrg(userId, input);
+    return { success: true, slug: org.slug };
+  } catch (err) {
+    return { success: false, error: err instanceof Error ? err.message : "오류가 발생했습니다." };
+  }
 };
 
 export const getOrgBySlugAction = async (slug: string) => {

--- a/apps/assassin/src/features/player/actions.ts
+++ b/apps/assassin/src/features/player/actions.ts
@@ -2,48 +2,35 @@
 
 import { revalidateSeasonBoard } from "@libs/cache/seasonBoard";
 import { getCurrentUser } from "@libs/supabase/auth";
-import OrgService from "@features/org/service";
 import PlayerService from "./service";
 import { PlayerPayload, PlayerUpdatePayload } from "./schema";
 
-const getOrgIdBySongId = async (songId: string): Promise<string> => {
-  const orgId = await OrgService.getOrgIdBySongId(songId);
-  if (!orgId) {
-    throw new Error(`Song with ID ${songId} does not exist.`);
-  }
-  return orgId;
+export const getPlayerAction = async (id: string, orgId: string) => {
+  const user = await getCurrentUser();
+  return await PlayerService.getPlayerById(id, orgId, user.id);
 };
 
-export const getPlayerAction = async (id: string) => {
+export const getPlayersBySongAction = async (songId: string, orgId: string) => {
   const user = await getCurrentUser();
-  return await PlayerService.getPlayerById(id, user.id);
+  return await PlayerService.getPlayersBySongId(songId, orgId, user.id);
 };
 
-export const getPlayersBySongAction = async (songId: string) => {
+export const createPlayerAction = async (orgId: string, data: PlayerPayload) => {
   const user = await getCurrentUser();
-  return await PlayerService.getPlayersBySongId(songId, user.id);
-};
-
-export const createPlayerAction = async (data: PlayerPayload) => {
-  const user = await getCurrentUser();
-  const result = await PlayerService.createPlayer(data, user.id);
-  const orgId = await getOrgIdBySongId(result.songId);
+  const result = await PlayerService.createPlayer(data, orgId, user.id);
   revalidateSeasonBoard(orgId);
   return result;
 };
 
-export const updatePlayerAction = async (id: string, data: PlayerUpdatePayload) => {
+export const updatePlayerAction = async (id: string, orgId: string, data: PlayerUpdatePayload) => {
   const user = await getCurrentUser();
-  const result = await PlayerService.updatePlayer(id, data, user.id);
-  const orgId = await getOrgIdBySongId(result.songId);
+  const result = await PlayerService.updatePlayer(id, orgId, data, user.id);
   revalidateSeasonBoard(orgId);
   return result;
 };
 
-export const deletePlayerAction = async (id: string) => {
+export const deletePlayerAction = async (id: string, orgId: string) => {
   const user = await getCurrentUser();
-  const existing = await PlayerService.getPlayerById(id, user.id);
-  const orgId = await getOrgIdBySongId(existing.songId);
-  await PlayerService.deletePlayer(id, user.id);
+  await PlayerService.deletePlayer(id, orgId, user.id);
   revalidateSeasonBoard(orgId);
 };

--- a/apps/assassin/src/features/player/mutations/useCreatePlayer.ts
+++ b/apps/assassin/src/features/player/mutations/useCreatePlayer.ts
@@ -9,7 +9,7 @@ export const useCreatePlayer = () => {
   const orgId = useOrgId();
 
   return useMutation({
-    mutationFn: (data: PlayerPayload) => createPlayerAction(data),
+    mutationFn: (data: PlayerPayload) => createPlayerAction(orgId, data),
     onSuccess: (createdPlayer) => {
       queryClient.invalidateQueries({ queryKey: playerKeys.bySong(orgId, createdPlayer.songId) });
     },

--- a/apps/assassin/src/features/player/mutations/useDeletePlayer.ts
+++ b/apps/assassin/src/features/player/mutations/useDeletePlayer.ts
@@ -8,7 +8,8 @@ export const useDeletePlayer = () => {
   const orgId = useOrgId();
 
   return useMutation({
-    mutationFn: (variables: { id: string; songId: string }) => deletePlayerAction(variables.id),
+    mutationFn: (variables: { id: string; songId: string }) =>
+      deletePlayerAction(variables.id, orgId),
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: playerKeys.bySong(orgId, variables.songId) });
     },

--- a/apps/assassin/src/features/player/mutations/useUpdatePlayer.ts
+++ b/apps/assassin/src/features/player/mutations/useUpdatePlayer.ts
@@ -10,7 +10,7 @@ export const useUpdatePlayer = () => {
 
   return useMutation({
     mutationFn: ({ id, data }: { id: string; data: PlayerUpdatePayload }) =>
-      updatePlayerAction(id, data),
+      updatePlayerAction(id, orgId, data),
     onSuccess: (updatedPlayer) => {
       queryClient.invalidateQueries({ queryKey: playerKeys.bySong(orgId, updatedPlayer.songId) });
       queryClient.invalidateQueries({

--- a/apps/assassin/src/features/player/queries/usePlayer.ts
+++ b/apps/assassin/src/features/player/queries/usePlayer.ts
@@ -8,6 +8,7 @@ export const usePlayer = (id: string) => {
 
   return useSuspenseQuery({
     queryKey: playerKeys.detail(orgId, id),
-    queryFn: () => getPlayerAction(id),
+    queryFn: () => getPlayerAction(id, orgId),
+    staleTime: 1000 * 60,
   });
 };

--- a/apps/assassin/src/features/player/queries/usePlayersBySong.ts
+++ b/apps/assassin/src/features/player/queries/usePlayersBySong.ts
@@ -10,7 +10,7 @@ export const usePlayersBySong = (songId: string) => {
 
   return useSuspenseQuery({
     queryKey: playerKeys.bySong(orgId, songId),
-    queryFn: () => getPlayersBySongAction(songId),
+    queryFn: () => getPlayersBySongAction(songId, orgId),
     select: (data) =>
       [...data].sort(
         (a, b) => INSTRUMENT_ORDER.indexOf(a.instrument) - INSTRUMENT_ORDER.indexOf(b.instrument),

--- a/apps/assassin/src/features/player/repository.ts
+++ b/apps/assassin/src/features/player/repository.ts
@@ -5,70 +5,69 @@ import { TransactionClient } from "@libs/prisma/types";
 
 type PlayerWithProfile = Player & { profile: Profile };
 
-async function getAllPlayers(): Promise<PlayerWithProfile[]> {
-  return await prisma.player.findMany({
-    where: { deletedAt: null },
-    include: { profile: true },
-    orderBy: { createdAt: "desc" },
-  });
-}
-
-async function getPlayerById(id: string): Promise<PlayerWithProfile | null> {
-  return await prisma.player.findUnique({
-    where: { id, deletedAt: null },
+async function getPlayerById(id: string, orgId: string): Promise<PlayerWithProfile | null> {
+  return prisma.player.findFirst({
+    where: { id, deletedAt: null, song: { season: { orgId } } },
     include: { profile: true },
   });
 }
 
-async function getPlayersBySongId(songId: string): Promise<PlayerWithProfile[]> {
-  return await prisma.player.findMany({
-    where: { songId, deletedAt: null },
+async function getPlayersBySongId(songId: string, orgId: string): Promise<PlayerWithProfile[]> {
+  return prisma.player.findMany({
+    where: { songId, deletedAt: null, song: { season: { orgId } } },
     include: { profile: true },
     orderBy: { createdAt: "asc" },
   });
 }
 
-async function createPlayer(input: PlayerPayload): Promise<PlayerWithProfile> {
-  return await prisma.player.create({
-    data: {
-      userId: input.userId,
-      instrument: input.instrument,
-      songId: input.songId,
-    },
+async function createPlayer(input: PlayerPayload, orgId: string): Promise<PlayerWithProfile> {
+  const song = await prisma.song.findFirst({
+    where: { id: input.songId, season: { orgId }, deletedAt: null },
+    select: { id: true },
+  });
+  if (!song) throw new Error("Song not found in org");
+
+  return prisma.player.create({
+    data: { userId: input.userId, instrument: input.instrument, songId: input.songId },
     include: { profile: true },
   });
 }
 
-async function updatePlayer(id: string, input: PlayerUpdatePayload): Promise<PlayerWithProfile> {
-  return await prisma.player.update({
+async function updatePlayer(
+  id: string,
+  orgId: string,
+  input: PlayerUpdatePayload,
+): Promise<PlayerWithProfile> {
+  const existing = await prisma.player.findFirst({
+    where: { id, deletedAt: null, song: { season: { orgId } } },
+    select: { id: true },
+  });
+  if (!existing) throw new Error("Player not found in org");
+
+  return prisma.player.update({
     where: { id },
-    data: {
-      userId: input.userId,
-      instrument: input.instrument,
-      songId: input.songId,
-    },
+    data: { userId: input.userId, instrument: input.instrument, songId: input.songId },
     include: { profile: true },
   });
 }
 
-async function deletePlayer(id: string, tx?: TransactionClient) {
+async function deletePlayer(id: string, orgId: string, tx?: TransactionClient) {
   const prismaClient = tx || prisma;
-  await prismaClient.player.update({
-    where: { id },
+  await prismaClient.player.updateMany({
+    where: { id, deletedAt: null, song: { season: { orgId } } },
     data: { deletedAt: new Date() },
   });
 }
 
-async function deletePlayersBySongId(songId: string, tx?: TransactionClient) {
+async function deletePlayersBySongId(songId: string, orgId: string, tx?: TransactionClient) {
   const prismaClient = tx || prisma;
   await prismaClient.player.updateMany({
-    where: { songId },
+    where: { songId, song: { season: { orgId } } },
     data: { deletedAt: new Date() },
   });
 }
 
 const PlayerRepository = {
-  getAllPlayers,
   getPlayerById,
   getPlayersBySongId,
   createPlayer,

--- a/apps/assassin/src/features/player/service.ts
+++ b/apps/assassin/src/features/player/service.ts
@@ -1,6 +1,5 @@
-import SongService from "@features/song/service";
-import OrgRepository from "@features/org/repository";
 import { assertOrgMember } from "@features/org/service";
+import SongRepository from "@features/song/repository";
 import {
   PlayerPayload,
   Player,
@@ -10,19 +9,14 @@ import {
 } from "./schema";
 import PlayerRepository from "./repository";
 
-const assertPlayerExists = async (playerId: string): Promise<Player> => {
-  const player = await PlayerRepository.getPlayerById(playerId);
-  const parsed = playerSchema.safeParse(player);
-  if (!parsed.success) {
-    throw new Error(`Player with ID ${playerId} does not exist.`);
-  }
-  return parsed.data;
-};
-
-const createPlayer = async (player: PlayerPayload, actorUserId: string): Promise<Player> => {
-  const orgId = await SongService.assertSongAccess(player.songId, actorUserId);
+const createPlayer = async (
+  player: PlayerPayload,
+  orgId: string,
+  actorUserId: string,
+): Promise<Player> => {
+  await assertOrgMember(actorUserId, orgId);
   await assertOrgMember(player.userId, orgId);
-  const result = await PlayerRepository.createPlayer(player);
+  const result = await PlayerRepository.createPlayer(player, orgId);
   const parsed = playerSchema.safeParse(result);
   if (!parsed.success) {
     throw new Error("Invalid player response from DB");
@@ -30,15 +24,23 @@ const createPlayer = async (player: PlayerPayload, actorUserId: string): Promise
   return parsed.data;
 };
 
-const getPlayerById = async (id: string, actorUserId: string): Promise<Player> => {
-  const parsed = await assertPlayerExists(id);
-  await SongService.assertSongAccess(parsed.songId, actorUserId);
-  return parsed;
+const getPlayerById = async (id: string, orgId: string, actorUserId: string): Promise<Player> => {
+  await assertOrgMember(actorUserId, orgId);
+  const player = await PlayerRepository.getPlayerById(id, orgId);
+  const parsed = playerSchema.safeParse(player);
+  if (!parsed.success) {
+    throw new Error(`Player with ID ${id} does not exist.`);
+  }
+  return parsed.data;
 };
 
-const getPlayersBySongId = async (songId: string, actorUserId: string): Promise<Player[]> => {
-  await SongService.assertSongAccess(songId, actorUserId);
-  const players = await PlayerRepository.getPlayersBySongId(songId);
+const getPlayersBySongId = async (
+  songId: string,
+  orgId: string,
+  actorUserId: string,
+): Promise<Player[]> => {
+  await assertOrgMember(actorUserId, orgId);
+  const players = await PlayerRepository.getPlayersBySongId(songId, orgId);
   const parsed = playerSchema.array().safeParse(players);
   if (!parsed.success) {
     throw new Error("Invalid player responses from DB");
@@ -46,36 +48,37 @@ const getPlayersBySongId = async (songId: string, actorUserId: string): Promise<
   return parsed.data;
 };
 
-const updatePlayer = async (id: string, player: PlayerUpdatePayload, actorUserId: string) => {
-  const existed = await getPlayerById(id, actorUserId);
+const updatePlayer = async (
+  id: string,
+  orgId: string,
+  player: PlayerUpdatePayload,
+  actorUserId: string,
+) => {
+  await assertOrgMember(actorUserId, orgId);
+
+  const existed = await PlayerRepository.getPlayerById(id, orgId);
+  const parsedExisted = playerSchema.safeParse(existed);
+  if (!parsedExisted.success) {
+    throw new Error(`Player with ID ${id} does not exist.`);
+  }
+
   const parsedInput = updatePlayerSchema.safeParse(player);
   if (!parsedInput.success) {
     throw new Error("Invalid player input");
   }
 
-  const sourceOrgId = await OrgRepository.getOrgIdBySongId(existed.songId);
-  if (!sourceOrgId) {
-    throw new Error(`Song with ID ${existed.songId} does not exist.`);
+  if (parsedInput.data.songId && parsedInput.data.songId !== parsedExisted.data.songId) {
+    const targetSong = await SongRepository.getSongByIdInOrg(parsedInput.data.songId, orgId);
+    if (!targetSong) throw new Error("Cross-org player move is not allowed");
   }
 
-  const targetSongId = parsedInput.data.songId ?? existed.songId;
-  const targetOrgId =
-    targetSongId === existed.songId
-      ? sourceOrgId
-      : await SongService.assertSongAccess(targetSongId, actorUserId);
-  if (targetOrgId !== sourceOrgId) {
-    throw new Error("Cross-org player move is not allowed");
+  const targetUserId = parsedInput.data.userId ?? parsedExisted.data.userId;
+  if (targetUserId !== parsedExisted.data.userId) {
+    await assertOrgMember(targetUserId, orgId);
   }
-  const targetUserId = parsedInput.data.userId ?? existed.userId;
-  await assertOrgMember(targetUserId, targetOrgId);
 
-  const newPlayerData = {
-    ...existed,
-    ...parsedInput.data,
-    songId: targetSongId,
-    userId: targetUserId,
-  };
-  const updatedPlayer = await PlayerRepository.updatePlayer(id, newPlayerData);
+  const newPlayerData = { ...parsedExisted.data, ...parsedInput.data };
+  const updatedPlayer = await PlayerRepository.updatePlayer(id, orgId, newPlayerData);
   const parsed = playerSchema.safeParse(updatedPlayer);
   if (!parsed.success) {
     throw new Error("Invalid player response from DB");
@@ -83,10 +86,13 @@ const updatePlayer = async (id: string, player: PlayerUpdatePayload, actorUserId
   return parsed.data;
 };
 
-const deletePlayer = async (id: string, actorUserId: string) => {
-  const player = await assertPlayerExists(id);
-  await SongService.assertSongAccess(player.songId, actorUserId);
-  await PlayerRepository.deletePlayer(id);
+const deletePlayer = async (id: string, orgId: string, actorUserId: string) => {
+  await assertOrgMember(actorUserId, orgId);
+  const player = await PlayerRepository.getPlayerById(id, orgId);
+  if (!playerSchema.safeParse(player).success) {
+    throw new Error(`Player with ID ${id} does not exist.`);
+  }
+  await PlayerRepository.deletePlayer(id, orgId);
 };
 
 const PlayerService = {

--- a/apps/assassin/src/features/rsvp/actions.ts
+++ b/apps/assassin/src/features/rsvp/actions.ts
@@ -2,31 +2,31 @@
 
 import { revalidateCalendar } from "@libs/cache/calendar";
 import { getCurrentUser } from "@libs/supabase/auth";
-import OrgService from "@features/org/service";
 import RsvpService from "./service";
 import type { RsvpWithProfile } from "./schema";
 
-export const getRsvpAttendeesAction = async (eventId: string): Promise<RsvpWithProfile[]> => {
+export const getRsvpAttendeesAction = async (
+  eventId: string,
+  orgId: string,
+): Promise<RsvpWithProfile[]> => {
   const user = await getCurrentUser();
-  return RsvpService.getAttendeesByEvent(eventId, user.id);
+  return RsvpService.getAttendeesByEvent(eventId, orgId, user.id);
 };
 
 export const getUserRsvpStatusAction = async (
   eventId: string,
+  orgId: string,
 ): Promise<"ATTENDING" | "NOT_ATTENDING" | null> => {
   const user = await getCurrentUser();
-  return RsvpService.getUserRsvpStatus(eventId, user.id);
+  return RsvpService.getUserRsvpStatus(eventId, orgId, user.id);
 };
 
 export const toggleRsvpAction = async (
   eventId: string,
+  orgId: string,
 ): Promise<{ status: "ATTENDING" | "NOT_ATTENDING" | null }> => {
   const user = await getCurrentUser();
-  const result = await RsvpService.toggleAttending(eventId, user.id);
-  const orgId = await OrgService.getOrgIdByEvent(eventId);
-  if (!orgId) {
-    throw new Error("CalendarEvent not found");
-  }
+  const result = await RsvpService.toggleAttending(eventId, orgId, user.id);
   revalidateCalendar(orgId);
   return result;
 };

--- a/apps/assassin/src/features/rsvp/mutations/useToggleRsvp.ts
+++ b/apps/assassin/src/features/rsvp/mutations/useToggleRsvp.ts
@@ -8,7 +8,7 @@ export const useToggleRsvp = (eventId: string) => {
   const orgId = useOrgId();
 
   return useMutation({
-    mutationFn: () => toggleRsvpAction(eventId),
+    mutationFn: () => toggleRsvpAction(eventId, orgId),
     onMutate: async () => {
       await queryClient.cancelQueries({ queryKey: rsvpKeys.byUser(orgId, eventId) });
 

--- a/apps/assassin/src/features/rsvp/queries/useRsvpByEvent.ts
+++ b/apps/assassin/src/features/rsvp/queries/useRsvpByEvent.ts
@@ -8,7 +8,7 @@ export const useRsvpByEvent = (eventId: string) => {
 
   return useQuery({
     queryKey: rsvpKeys.byEvent(orgId, eventId),
-    queryFn: () => getRsvpAttendeesAction(eventId),
+    queryFn: () => getRsvpAttendeesAction(eventId, orgId),
     staleTime: 1000 * 60,
   });
 };

--- a/apps/assassin/src/features/rsvp/queries/useUserRsvpStatus.ts
+++ b/apps/assassin/src/features/rsvp/queries/useUserRsvpStatus.ts
@@ -8,7 +8,7 @@ export const useUserRsvpStatus = (eventId: string) => {
 
   return useQuery({
     queryKey: rsvpKeys.byUser(orgId, eventId),
-    queryFn: () => getUserRsvpStatusAction(eventId),
+    queryFn: () => getUserRsvpStatusAction(eventId, orgId),
     staleTime: 1000 * 60,
   });
 };

--- a/apps/assassin/src/features/rsvp/repository.ts
+++ b/apps/assassin/src/features/rsvp/repository.ts
@@ -1,20 +1,31 @@
 import { prisma } from "@libs/prisma/client";
 
-async function getRsvpsByEvent(eventId: string) {
+async function getRsvpsByEvent(eventId: string, orgId: string) {
   return prisma.calendarEventRsvp.findMany({
-    where: { eventId, status: "ATTENDING" },
+    where: { eventId, status: "ATTENDING", event: { orgId } },
     include: { profile: { select: { id: true, name: true, realName: true } } },
     orderBy: { createdAt: "asc" },
   });
 }
 
-async function getRsvpByEventAndUser(eventId: string, userId: string) {
-  return prisma.calendarEventRsvp.findUnique({
-    where: { eventId_userId: { eventId, userId } },
+async function getRsvpByEventAndUser(eventId: string, userId: string, orgId: string) {
+  return prisma.calendarEventRsvp.findFirst({
+    where: { eventId, userId, event: { orgId } },
   });
 }
 
-async function upsertRsvp(eventId: string, userId: string, status: "ATTENDING" | "NOT_ATTENDING") {
+async function upsertRsvp(
+  eventId: string,
+  userId: string,
+  status: "ATTENDING" | "NOT_ATTENDING",
+  orgId: string,
+) {
+  const event = await prisma.calendarEvent.findFirst({
+    where: { id: eventId, orgId },
+    select: { id: true },
+  });
+  if (!event) throw new Error("Event not found in org");
+
   return prisma.calendarEventRsvp.upsert({
     where: { eventId_userId: { eventId, userId } },
     create: { eventId, userId, status },
@@ -22,9 +33,9 @@ async function upsertRsvp(eventId: string, userId: string, status: "ATTENDING" |
   });
 }
 
-async function deleteRsvp(eventId: string, userId: string) {
-  return prisma.calendarEventRsvp.delete({
-    where: { eventId_userId: { eventId, userId } },
+async function deleteRsvp(eventId: string, userId: string, orgId: string) {
+  return prisma.calendarEventRsvp.deleteMany({
+    where: { eventId, userId, event: { orgId } },
   });
 }
 

--- a/apps/assassin/src/features/rsvp/service.ts
+++ b/apps/assassin/src/features/rsvp/service.ts
@@ -1,21 +1,15 @@
 import { assertOrgMember } from "@features/org/service";
-import OrgRepository from "@features/org/repository";
 import RsvpRepository from "./repository";
 import { calendarEventRsvpSchema, rsvpWithProfileSchema } from "./schema";
 import type { RsvpWithProfile } from "./schema";
-import { z } from "zod";
 
-const assertEventAccess = async (eventId: string, userId: string): Promise<string> => {
-  const orgId = await OrgRepository.getOrgIdByEvent(eventId);
-  const parsedOrgId = z.uuid().safeParse(orgId);
-  if (!parsedOrgId.success) throw new Error("CalendarEvent not found");
-  await assertOrgMember(userId, parsedOrgId.data);
-  return parsedOrgId.data;
-};
-
-const getAttendeesByEvent = async (eventId: string, userId: string): Promise<RsvpWithProfile[]> => {
-  await assertEventAccess(eventId, userId);
-  const rsvps = await RsvpRepository.getRsvpsByEvent(eventId);
+const getAttendeesByEvent = async (
+  eventId: string,
+  orgId: string,
+  userId: string,
+): Promise<RsvpWithProfile[]> => {
+  await assertOrgMember(userId, orgId);
+  const rsvps = await RsvpRepository.getRsvpsByEvent(eventId, orgId);
   return rsvps
     .map((r) => rsvpWithProfileSchema.safeParse(r))
     .filter((r) => r.success)
@@ -24,10 +18,11 @@ const getAttendeesByEvent = async (eventId: string, userId: string): Promise<Rsv
 
 const getUserRsvpStatus = async (
   eventId: string,
+  orgId: string,
   userId: string,
 ): Promise<"ATTENDING" | "NOT_ATTENDING" | null> => {
-  await assertEventAccess(eventId, userId);
-  const rsvp = await RsvpRepository.getRsvpByEventAndUser(eventId, userId);
+  await assertOrgMember(userId, orgId);
+  const rsvp = await RsvpRepository.getRsvpByEventAndUser(eventId, userId, orgId);
   if (!rsvp) return null;
   const parsed = calendarEventRsvpSchema.safeParse(rsvp);
   if (!parsed.success) return null;
@@ -36,17 +31,18 @@ const getUserRsvpStatus = async (
 
 const toggleAttending = async (
   eventId: string,
+  orgId: string,
   userId: string,
 ): Promise<{ status: "ATTENDING" | "NOT_ATTENDING" | null }> => {
-  await assertEventAccess(eventId, userId);
-  const existing = await RsvpRepository.getRsvpByEventAndUser(eventId, userId);
+  await assertOrgMember(userId, orgId);
+  const existing = await RsvpRepository.getRsvpByEventAndUser(eventId, userId, orgId);
 
   if (existing?.status === "ATTENDING") {
-    await RsvpRepository.deleteRsvp(eventId, userId);
+    await RsvpRepository.deleteRsvp(eventId, userId, orgId);
     return { status: null };
   }
 
-  await RsvpRepository.upsertRsvp(eventId, userId, "ATTENDING");
+  await RsvpRepository.upsertRsvp(eventId, userId, "ATTENDING", orgId);
   return { status: "ATTENDING" };
 };
 

--- a/apps/assassin/src/features/season/hooks/useRealtimeSeasonSync.ts
+++ b/apps/assassin/src/features/season/hooks/useRealtimeSeasonSync.ts
@@ -27,7 +27,7 @@ export const useRealtimeSeasonSync = () => {
         }
 
         queryClient.invalidateQueries({ queryKey: seasonKeys.org(orgId) });
-        queryClient.invalidateQueries({ queryKey: songKeys.org(orgId) });
+        queryClient.invalidateQueries({ queryKey: songKeys.byOrg(orgId) });
         queryClient.invalidateQueries({ queryKey: eventSongKeys.org(orgId) });
       })
       .subscribe();

--- a/apps/assassin/src/features/season/mutations/useDeleteSeason.ts
+++ b/apps/assassin/src/features/season/mutations/useDeleteSeason.ts
@@ -11,9 +11,10 @@ export const useDeleteSeason = () => {
 
   return useMutation({
     mutationFn: ({ id }: { id: string }) => deleteSeasonAction(id, orgId),
-    onSuccess: () => {
+    onSuccess: (_, { id }) => {
       queryClient.invalidateQueries({ queryKey: seasonKeys.org(orgId) });
-      queryClient.invalidateQueries({ queryKey: songKeys.org(orgId) });
+      queryClient.invalidateQueries({ queryKey: songKeys.byOrg(orgId) });
+      queryClient.invalidateQueries({ queryKey: songKeys.bySeason(orgId, id) });
       queryClient.invalidateQueries({ queryKey: eventSongKeys.org(orgId) });
     },
   });

--- a/apps/assassin/src/features/season/repository.ts
+++ b/apps/assassin/src/features/season/repository.ts
@@ -29,12 +29,15 @@ async function createSeason(input: SeasonPayload, orgId: string): Promise<Season
   return season;
 }
 
-async function updateSeason(id: string, orgId: string, input: SeasonUpdatePayload): Promise<Season> {
+async function updateSeason(
+  id: string,
+  orgId: string,
+  input: SeasonUpdatePayload,
+): Promise<Season> {
   const existing = await prisma.season.findFirst({ where: { id, orgId } });
-  if (!existing) {
-    throw new Error(`Season with ID ${id} not found in this org.`);
-  }
-  const season = await prisma.season.update({
+  if (!existing) throw new Error("Season not found in org");
+
+  return prisma.season.update({
     where: { id },
     data: {
       name: input.name,
@@ -42,16 +45,11 @@ async function updateSeason(id: string, orgId: string, input: SeasonUpdatePayloa
       isArchived: input.isArchived,
     },
   });
-  return season;
 }
 
 async function deleteSeason(id: string, orgId: string): Promise<void> {
-  const existing = await prisma.season.findFirst({ where: { id, orgId } });
-  if (!existing) {
-    throw new Error(`Season with ID ${id} not found in this org.`);
-  }
-  await prisma.season.delete({
-    where: { id },
+  await prisma.season.deleteMany({
+    where: { id, orgId },
   });
 }
 

--- a/apps/assassin/src/features/season/service.ts
+++ b/apps/assassin/src/features/season/service.ts
@@ -106,7 +106,7 @@ const deleteSeason = async (id: string, orgId: string, userId: string): Promise<
   await assertOrgMember(userId, orgId, "OWNER");
   await assertSeasonExists(id, orgId);
 
-  const activeSongs = await SongRepository.getSongsBySeasonId(id);
+  const activeSongs = await SongRepository.getSongsBySeasonId(id, orgId);
 
   const parsedSongs = songSchema.array().safeParse(activeSongs);
 

--- a/apps/assassin/src/features/season/service.ts
+++ b/apps/assassin/src/features/season/service.ts
@@ -119,7 +119,7 @@ const deleteSeason = async (id: string, orgId: string, userId: string): Promise<
       for (const song of parsedSongs.data) {
         await PlayerRepository.deletePlayersBySongId(song.id, tx);
         await CommentRepository.deleteCommentsBySongId(song.id, tx);
-        await SongRepository.deleteSong(song.id, tx);
+        await SongRepository.deleteSong(song.id, orgId, tx);
       }
     });
 

--- a/apps/assassin/src/features/season/service.ts
+++ b/apps/assassin/src/features/season/service.ts
@@ -117,8 +117,8 @@ const deleteSeason = async (id: string, orgId: string, userId: string): Promise<
   try {
     await prisma.$transaction(async (tx) => {
       for (const song of parsedSongs.data) {
-        await PlayerRepository.deletePlayersBySongId(song.id, tx);
-        await CommentRepository.deleteCommentsBySongId(song.id, tx);
+        await PlayerRepository.deletePlayersBySongId(song.id, orgId, tx);
+        await CommentRepository.deleteCommentsBySongId(song.id, orgId, tx);
         await SongRepository.deleteSong(song.id, orgId, tx);
       }
     });

--- a/apps/assassin/src/features/song/actions.ts
+++ b/apps/assassin/src/features/song/actions.ts
@@ -5,9 +5,9 @@ import { getCurrentUser } from "@libs/supabase/auth";
 import SongService from "./service";
 import { SongUpdatePayload } from "./schema";
 
-export const getSongAction = async (id: string) => {
+export const getSongAction = async (id: string, orgId: string) => {
   const user = await getCurrentUser();
-  return await SongService.getSongByIdForUser(id, user.id);
+  return await SongService.getSongByIdForUser(id, orgId, user.id);
 };
 
 export const getSongsBySeasonAction = async (seasonId: string, orgId: string) => {

--- a/apps/assassin/src/features/song/actions.ts
+++ b/apps/assassin/src/features/song/actions.ts
@@ -4,7 +4,6 @@ import { revalidateSeasonBoard } from "@libs/cache/seasonBoard";
 import { getCurrentUser } from "@libs/supabase/auth";
 import SongService from "./service";
 import { SongUpdatePayload } from "./schema";
-import SongRepository from "./repository";
 
 export const getSongAction = async (id: string) => {
   const user = await getCurrentUser();
@@ -33,24 +32,15 @@ export const createSongAction = async (
   return result;
 };
 
-export const updateSongAction = async (id: string, data: SongUpdatePayload) => {
+export const updateSongAction = async (id: string, orgId: string, data: SongUpdatePayload) => {
   const user = await getCurrentUser();
-  const result = await SongService.updateSong(id, data, user.id);
-  const orgId = await SongRepository.getSongOrgIdById(id);
-  if (!orgId) {
-    throw new Error(`Song with ID ${id} does not exist.`);
-  }
+  const song = await SongService.updateSong(id, orgId, data, user.id);
   revalidateSeasonBoard(orgId);
-  return result;
+  return song;
 };
 
-export const deleteSongAction = async (id: string) => {
+export const deleteSongAction = async (id: string, orgId: string) => {
   const user = await getCurrentUser();
-  const orgId = await SongRepository.getSongOrgIdById(id);
-  if (!orgId) {
-    throw new Error(`Song with ID ${id} does not exist.`);
-  }
-  const result = await SongService.deleteSong(id, user.id);
+  await SongService.deleteSong(id, orgId, user.id);
   revalidateSeasonBoard(orgId);
-  return result;
 };

--- a/apps/assassin/src/features/song/hooks/useRealtimeSongSync.ts
+++ b/apps/assassin/src/features/song/hooks/useRealtimeSongSync.ts
@@ -1,80 +1,91 @@
 import { useEffect, useMemo } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { songKeys } from "@features/song/queries/keys";
-import { eventSongKeys } from "@features/eventSong/queries/keys";
-import { seasonKeys } from "@features/season/queries/keys";
 import { createBrowserSupabaseClient } from "@/libs/supabase/client";
 import { useOrgId } from "@/components/org/OrgProvider";
-import type { Season } from "@features/season/schema";
 
-type RealtimeRow = { seasonId?: string; season_id?: string };
-
-const getPayloadSeasonId = (payload: { new: unknown; old: unknown }): string | null => {
-  const next = payload.new as RealtimeRow | null;
-  const prev = payload.old as RealtimeRow | null;
-  return next?.seasonId ?? next?.season_id ?? prev?.seasonId ?? prev?.season_id ?? null;
+type SongRow = {
+  id?: string;
+  seasonId?: string;
+  season_id?: string;
 };
 
-const hasSeasonId = (value: unknown): value is { id: string } => {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "id" in value &&
-    typeof (value as { id?: unknown }).id === "string"
-  );
+const getSongId = (row: SongRow | undefined | null): string | null => {
+  const songId = row?.id ?? null;
+  return typeof songId === "string" ? songId : null;
 };
 
-export const useRealtimeSongSync = () => {
+const getSeasonId = (row: SongRow | undefined | null): string | null => {
+  const seasonId = row?.seasonId ?? row?.season_id ?? null;
+  return typeof seasonId === "string" ? seasonId : null;
+};
+
+export const useRealtimeSongSync = (songId: string) => {
   const queryClient = useQueryClient();
   const orgId = useOrgId();
-
   const supabase = useMemo(() => createBrowserSupabaseClient(), []);
 
   useEffect(() => {
-    const songsChannel = supabase
-      .channel(`realtime:song:${orgId}`)
+    const channel = supabase
+      .channel(`realtime:song:detail:${orgId}:${songId}`)
       .on("postgres_changes", { event: "*", schema: "public", table: "song" }, (payload) => {
-        const seasonId = getPayloadSeasonId(payload);
-        if (!seasonId) return;
+        const nextRow = payload.new as SongRow | undefined;
+        const prevRow = payload.old as SongRow | undefined;
+        const affectedSongId = getSongId(nextRow) ?? getSongId(prevRow);
 
-        const seasonQueryData = queryClient.getQueriesData<Season | Season[]>({
-          queryKey: seasonKeys.org(orgId),
-        });
-
-        let hasScopedSeasonCache = false;
-        let belongsToCurrentOrg = false;
-
-        for (const [, data] of seasonQueryData) {
-          if (Array.isArray(data)) {
-            if (data.length > 0) hasScopedSeasonCache = true;
-            if (data.some((season) => hasSeasonId(season) && season.id === seasonId)) {
-              belongsToCurrentOrg = true;
-              break;
-            }
-            continue;
-          }
-
-          if (hasSeasonId(data)) {
-            hasScopedSeasonCache = true;
-            if (data.id === seasonId) {
-              belongsToCurrentOrg = true;
-              break;
-            }
-          }
-        }
-
-        if (hasScopedSeasonCache && !belongsToCurrentOrg) {
-          return;
-        }
-
-        queryClient.invalidateQueries({ queryKey: songKeys.byOrg(orgId) });
-        queryClient.invalidateQueries({ queryKey: songKeys.bySeason(orgId, seasonId) });
-        queryClient.invalidateQueries({ queryKey: eventSongKeys.org(orgId) });
+        if (affectedSongId && affectedSongId !== songId) return;
+        queryClient.invalidateQueries({ queryKey: songKeys.detail(orgId, songId) });
       })
       .subscribe();
 
     return () => {
-      supabase.removeChannel(songsChannel);
+      supabase.removeChannel(channel);
     };
-  }, [orgId, queryClient, supabase]);
+  }, [orgId, queryClient, songId, supabase]);
+};
+
+export const useRealtimeSongsBySeasonSync = (seasonIds: string[]) => {
+  const queryClient = useQueryClient();
+  const orgId = useOrgId();
+  const supabase = useMemo(() => createBrowserSupabaseClient(), []);
+
+  useEffect(() => {
+    if (seasonIds.length === 0) return;
+
+    const channel = supabase
+      .channel(`realtime:song:season:${orgId}`)
+      .on("postgres_changes", { event: "*", schema: "public", table: "song" }, (payload) => {
+        const nextRow = payload.new as SongRow | undefined;
+        const prevRow = payload.old as SongRow | undefined;
+        const nextSeasonId = getSeasonId(nextRow);
+        const prevSeasonId = getSeasonId(prevRow);
+
+        if (
+          nextSeasonId !== null &&
+          prevSeasonId !== null &&
+          !seasonIds.includes(nextSeasonId) &&
+          !seasonIds.includes(prevSeasonId)
+        ) {
+          return;
+        }
+
+        if (nextSeasonId === null && prevSeasonId === null) {
+          seasonIds.forEach((seasonId) => {
+            queryClient.invalidateQueries({ queryKey: songKeys.bySeason(orgId, seasonId) });
+          });
+          return;
+        }
+
+        seasonIds.forEach((seasonId) => {
+          if (seasonId === nextSeasonId || seasonId === prevSeasonId) {
+            queryClient.invalidateQueries({ queryKey: songKeys.bySeason(orgId, seasonId) });
+          }
+        });
+      })
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [orgId, queryClient, seasonIds, supabase]);
 };

--- a/apps/assassin/src/features/song/hooks/useRealtimeSongSync.ts
+++ b/apps/assassin/src/features/song/hooks/useRealtimeSongSync.ts
@@ -67,7 +67,8 @@ export const useRealtimeSongSync = () => {
           return;
         }
 
-        queryClient.invalidateQueries({ queryKey: songKeys.org(orgId) });
+        queryClient.invalidateQueries({ queryKey: songKeys.byOrg(orgId) });
+        queryClient.invalidateQueries({ queryKey: songKeys.bySeason(orgId, seasonId) });
         queryClient.invalidateQueries({ queryKey: eventSongKeys.org(orgId) });
       })
       .subscribe();

--- a/apps/assassin/src/features/song/mutations/useCreateSong.ts
+++ b/apps/assassin/src/features/song/mutations/useCreateSong.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { createSongAction } from "../actions";
 import { songKeys } from "../queries/keys";
+import type { Song } from "../schema";
 import type { SongFormData } from "../hooks/useSongForm";
 import { useOrgId } from "@/components/org/OrgProvider";
 
@@ -10,8 +11,19 @@ export const useCreateSong = () => {
 
   return useMutation({
     mutationFn: (data: SongFormData) => createSongAction(orgId, data),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: songKeys.org(orgId) });
+
+    onSuccess: (song) => {
+      queryClient.setQueryData(songKeys.detail(orgId, song.id), song);
+
+      queryClient.setQueriesData<Song[]>(
+        { queryKey: songKeys.bySeason(orgId, song.seasonId) },
+        (old) => {
+          const list = old ?? [];
+          return [...list, song].sort((a, b) => a.sortOrder - b.sortOrder);
+        },
+      );
+
+      queryClient.invalidateQueries({ queryKey: songKeys.byOrg(orgId) });
     },
   });
 };

--- a/apps/assassin/src/features/song/mutations/useDeleteSong.ts
+++ b/apps/assassin/src/features/song/mutations/useDeleteSong.ts
@@ -9,7 +9,7 @@ export const useDeleteSong = () => {
   const orgId = useOrgId();
 
   return useMutation({
-    mutationFn: ({ id }: { id: string; seasonId?: string }) => deleteSongAction(id),
+    mutationFn: ({ id }: { id: string; seasonId?: string }) => deleteSongAction(id, orgId),
 
     onSuccess: (_, { id, seasonId }) => {
       if (seasonId) {

--- a/apps/assassin/src/features/song/mutations/useDeleteSong.ts
+++ b/apps/assassin/src/features/song/mutations/useDeleteSong.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { deleteSongAction } from "../actions";
 import { songKeys } from "../queries/keys";
-import { eventSongKeys } from "@features/eventSong/queries/keys";
+import type { Song } from "../schema";
 import { useOrgId } from "@/components/org/OrgProvider";
 
 export const useDeleteSong = () => {
@@ -10,9 +10,18 @@ export const useDeleteSong = () => {
 
   return useMutation({
     mutationFn: ({ id }: { id: string; seasonId?: string }) => deleteSongAction(id),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: songKeys.org(orgId) });
-      queryClient.invalidateQueries({ queryKey: eventSongKeys.org(orgId) });
+
+    onSuccess: (_, { id, seasonId }) => {
+      if (seasonId) {
+        queryClient.setQueriesData<Song[]>(
+          { queryKey: songKeys.bySeason(orgId, seasonId) },
+          (old) => old?.filter((s) => s.id !== id),
+        );
+      }
+
+      queryClient.removeQueries({ queryKey: songKeys.detail(orgId, id) });
+
+      queryClient.invalidateQueries({ queryKey: songKeys.byOrg(orgId) });
     },
   });
 };

--- a/apps/assassin/src/features/song/mutations/useUpdateSong.ts
+++ b/apps/assassin/src/features/song/mutations/useUpdateSong.ts
@@ -1,8 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { updateSongAction } from "../actions";
 import { songKeys } from "../queries/keys";
-import { eventSongKeys } from "@features/eventSong/queries/keys";
-import type { SongUpdatePayload } from "../schema";
+import type { Song, SongUpdatePayload } from "../schema";
 import { useOrgId } from "@/components/org/OrgProvider";
 
 export const useUpdateSong = () => {
@@ -12,9 +11,16 @@ export const useUpdateSong = () => {
   return useMutation({
     mutationFn: ({ id, data }: { id: string; data: SongUpdatePayload }) =>
       updateSongAction(id, data),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: songKeys.org(orgId) });
-      queryClient.invalidateQueries({ queryKey: eventSongKeys.org(orgId) });
+
+    onSuccess: (song) => {
+      queryClient.setQueryData(songKeys.detail(orgId, song.id), song);
+
+      queryClient.setQueriesData<Song[]>(
+        { queryKey: songKeys.bySeason(orgId, song.seasonId) },
+        (old) => old?.map((s) => (s.id === song.id ? song : s)),
+      );
+
+      queryClient.invalidateQueries({ queryKey: songKeys.byOrg(orgId) });
     },
   });
 };

--- a/apps/assassin/src/features/song/mutations/useUpdateSong.ts
+++ b/apps/assassin/src/features/song/mutations/useUpdateSong.ts
@@ -10,7 +10,7 @@ export const useUpdateSong = () => {
 
   return useMutation({
     mutationFn: ({ id, data }: { id: string; data: SongUpdatePayload }) =>
-      updateSongAction(id, data),
+      updateSongAction(id, orgId, data),
 
     onSuccess: (song) => {
       queryClient.setQueryData(songKeys.detail(orgId, song.id), song);

--- a/apps/assassin/src/features/song/queries/keys.ts
+++ b/apps/assassin/src/features/song/queries/keys.ts
@@ -1,8 +1,6 @@
 export const songKeys = {
-  all: ["songs"] as const,
-  org: (orgId: string) => [...songKeys.all, { orgId }] as const,
-  lists: (orgId: string) => [...songKeys.org(orgId), "list"] as const,
+  byOrg: (orgId: string) => ["songs", "list", { orgId }] as const,
   bySeason: (orgId: string, seasonId: string) =>
-    [...songKeys.org(orgId), "bySeason", { seasonId }] as const,
-  detail: (orgId: string, id: string) => [...songKeys.org(orgId), "detail", { id }] as const,
+    ["songs", "bySeason", { orgId, seasonId }] as const,
+  detail: (orgId: string, id: string) => ["songs", "detail", { orgId, id }] as const,
 };

--- a/apps/assassin/src/features/song/queries/useSong.ts
+++ b/apps/assassin/src/features/song/queries/useSong.ts
@@ -8,6 +8,6 @@ export const useSong = (id: string) => {
 
   return useSuspenseQuery({
     queryKey: songKeys.detail(orgId, id),
-    queryFn: () => getSongAction(id),
+    queryFn: () => getSongAction(id, orgId),
   });
 };

--- a/apps/assassin/src/features/song/repository.ts
+++ b/apps/assassin/src/features/song/repository.ts
@@ -3,24 +3,6 @@ import type { Song } from "@generated/prisma/client";
 import { SongPayload, SongUpdatePayload } from "./schema";
 import { TransactionClient } from "@libs/prisma/types";
 
-async function getAllSongs(): Promise<Song[]> {
-  const songs = await prisma.song.findMany({
-    where: { deletedAt: null },
-    orderBy: { createdAt: "desc" },
-  });
-  return songs;
-}
-
-async function getSongById(id: string): Promise<Song | null> {
-  const song = await prisma.song.findFirst({
-    where: {
-      id,
-      deletedAt: null,
-    },
-  });
-  return song;
-}
-
 async function getSongByIdInOrg(id: string, orgId: string): Promise<Song | null> {
   return await prisma.song.findFirst({
     where: {
@@ -33,11 +15,12 @@ async function getSongByIdInOrg(id: string, orgId: string): Promise<Song | null>
   });
 }
 
-async function getSongsBySeasonId(seasonId: string): Promise<Song[]> {
+async function getSongsBySeasonId(seasonId: string, orgId: string): Promise<Song[]> {
   const songs = await prisma.song.findMany({
     where: {
-      seasonId: seasonId,
+      seasonId,
       deletedAt: null,
+      season: { orgId },
     },
   });
   return songs;
@@ -45,6 +28,7 @@ async function getSongsBySeasonId(seasonId: string): Promise<Song[]> {
 
 async function getMaxSortOrderBySeasonId(
   seasonId: string,
+  orgId: string,
   tx?: TransactionClient,
 ): Promise<bigint | number | null> {
   const prismaClient = tx || prisma;
@@ -52,6 +36,7 @@ async function getMaxSortOrderBySeasonId(
     where: {
       seasonId,
       deletedAt: null,
+      season: { orgId },
     },
     _max: {
       sortOrder: true,
@@ -61,12 +46,17 @@ async function getMaxSortOrderBySeasonId(
   return result._max.sortOrder ?? null;
 }
 
-async function lockSeasonSongsForUpdate(seasonId: string, tx?: TransactionClient): Promise<void> {
+async function lockSeasonSongsForUpdate(
+  seasonId: string,
+  orgId: string,
+  tx?: TransactionClient,
+): Promise<void> {
   const prismaClient = tx || prisma;
   await prismaClient.$queryRaw`
     SELECT id
     FROM season
     WHERE id = ${seasonId}
+    AND "orgId" = ${orgId}
     FOR UPDATE
   `;
 }
@@ -116,8 +106,6 @@ async function deleteSong(id: string, orgId: string, tx?: TransactionClient) {
 }
 
 const SongRepository = {
-  getAllSongs,
-  getSongById,
   getSongByIdInOrg,
   getSongsBySeasonId,
   getMaxSortOrderBySeasonId,

--- a/apps/assassin/src/features/song/repository.ts
+++ b/apps/assassin/src/features/song/repository.ts
@@ -106,7 +106,7 @@ async function createSong(input: SongPayload, tx?: TransactionClient): Promise<S
 }
 
 async function updateSong(id: string, input: SongUpdatePayload): Promise<Song> {
-  const song = await prisma.song.update({
+  return prisma.song.update({
     where: { id },
     data: {
       name: input.name,
@@ -117,13 +117,12 @@ async function updateSong(id: string, input: SongUpdatePayload): Promise<Song> {
       seasonId: input.seasonId,
     },
   });
-  return song;
 }
 
-async function deleteSong(id: string, tx?: TransactionClient) {
+async function deleteSong(id: string, orgId: string, tx?: TransactionClient) {
   const prismaClient = tx || prisma;
-  await prismaClient.song.update({
-    where: { id },
+  await prismaClient.song.updateMany({
+    where: { id, season: { orgId }, deletedAt: null },
     data: { deletedAt: new Date() },
   });
 }

--- a/apps/assassin/src/features/song/service.ts
+++ b/apps/assassin/src/features/song/service.ts
@@ -139,59 +139,44 @@ const getSongsBySeasonId = async (
   return parsed.data;
 };
 
-const updateSong = async (id: string, song: SongUpdatePayload, userId: string) => {
-  const existed = await getSongById(id);
+const updateSong = async (id: string, orgId: string, song: SongUpdatePayload, userId: string) => {
+  await assertOrgMember(userId, orgId);
 
-  if (!existed) {
-    throw new Error(`Song with ID ${id} does not exist.`);
-  }
+  const existed = await SongRepository.getSongByIdInOrg(id, orgId);
+  if (!existed) throw new Error("Song not found");
 
-  const sourceOrgId = await assertSongAccess(id, userId);
+  const parsedExisted = songSchema.safeParse(existed);
+  if (!parsedExisted.success) throw new Error("Invalid song data");
 
   const parsedInput = updateSongSchema.safeParse(song);
+  if (!parsedInput.success) throw new Error("Invalid song input");
 
-  if (!parsedInput.success) {
-    throw new Error("Invalid song input");
-  }
-
-  const targetSeasonId = parsedInput.data.seasonId ?? existed.seasonId;
+  const targetSeasonId = parsedInput.data.seasonId ?? parsedExisted.data.seasonId;
   const targetSeason = await prisma.season.findFirst({
     where: { id: targetSeasonId },
     select: { orgId: true },
   });
   if (!targetSeason?.orgId) throw new Error("Season not found");
-  if (targetSeason.orgId !== sourceOrgId) {
-    throw new Error("Cross-org season move is not allowed");
-  }
-  await assertOrgMember(userId, targetSeason.orgId);
+  if (targetSeason.orgId !== orgId) throw new Error("Cross-org season move is not allowed");
 
-  const newSongData: Song = { ...existed, ...parsedInput.data };
+  const newSongData: Song = { ...parsedExisted.data, ...parsedInput.data };
 
   const updatedSong = await SongRepository.updateSong(id, newSongData);
 
   const parsedOutput = songSchema.safeParse(updatedSong);
-
-  if (!parsedOutput.success) {
-    throw new Error("Invalid song response from DB");
-  }
+  if (!parsedOutput.success) throw new Error("Invalid song response from DB");
 
   return parsedOutput.data;
 };
 
-const deleteSong = async (id: string, userId: string) => {
-  const song = await SongRepository.getSongById(id);
-
-  if (!song) {
-    throw new Error(`Song with ID ${id} does not exist.`);
-  }
-
-  await assertSongAccess(id, userId);
+const deleteSong = async (id: string, orgId: string, userId: string) => {
+  await assertOrgMember(userId, orgId);
 
   try {
     await prisma.$transaction(async (tx) => {
       await PlayerRepository.deletePlayersBySongId(id, tx);
       await CommentRepository.deleteCommentsBySongId(id, tx);
-      await SongRepository.deleteSong(id, tx);
+      await SongRepository.deleteSong(id, orgId, tx);
     });
   } catch (error) {
     console.error(`Failed to delete song ${id}:`, error);

--- a/apps/assassin/src/features/song/service.ts
+++ b/apps/assassin/src/features/song/service.ts
@@ -147,8 +147,8 @@ const deleteSong = async (id: string, orgId: string, userId: string) => {
 
   try {
     await prisma.$transaction(async (tx) => {
-      await PlayerRepository.deletePlayersBySongId(id, tx);
-      await CommentRepository.deleteCommentsBySongId(id, tx);
+      await PlayerRepository.deletePlayersBySongId(id, orgId, tx);
+      await CommentRepository.deleteCommentsBySongId(id, orgId, tx);
       await SongRepository.deleteSong(id, orgId, tx);
     });
   } catch (error) {

--- a/apps/assassin/src/features/song/service.ts
+++ b/apps/assassin/src/features/song/service.ts
@@ -7,20 +7,6 @@ import { prisma } from "@libs/prisma/client";
 import PlayerRepository from "@features/player/repository";
 import CommentRepository from "@features/comment/repository";
 
-const assertSongExists = async (songId: string): Promise<void> => {
-  const song = await SongRepository.getSongById(songId);
-
-  if (!song) {
-    throw new Error(`Song with ID ${songId} does not exist.`);
-  }
-
-  const parsed = songSchema.safeParse(song);
-
-  if (!parsed.success) {
-    throw new Error(`Invalid song response from DB for ID ${songId}.`);
-  }
-};
-
 const assertSongAccess = async (songId: string, userId: string): Promise<string> => {
   const orgId = await OrgRepository.getOrgIdBySongId(songId);
   if (!orgId) {
@@ -76,9 +62,9 @@ const createSong = async (song: SongPayload, orgId: string) => {
   let result;
   try {
     result = await prisma.$transaction(async (tx) => {
-      await SongRepository.lockSeasonForUpdate(song.seasonId, tx);
+      await SongRepository.lockSeasonForUpdate(song.seasonId, orgId, tx);
 
-      const maxSortOrder = await SongRepository.getMaxSortOrderBySeasonId(song.seasonId, tx);
+      const maxSortOrder = await SongRepository.getMaxSortOrderBySeasonId(song.seasonId, orgId, tx);
       const nextSortOrder = (maxSortOrder ? Number(maxSortOrder) : 0) + 1;
 
       return await SongRepository.createSong(
@@ -107,20 +93,6 @@ const createSong = async (song: SongPayload, orgId: string) => {
   return parsed.data;
 };
 
-const getSongById = async (id: string): Promise<Song | null> => {
-  const song = await SongRepository.getSongById(id);
-
-  if (!song) return null;
-
-  const parsed = songSchema.safeParse(song);
-
-  if (!parsed.success) {
-    throw new Error("Invalid song response from DB");
-  }
-
-  return parsed.data;
-};
-
 const getSongsBySeasonId = async (
   seasonId: string,
   orgId: string,
@@ -129,7 +101,7 @@ const getSongsBySeasonId = async (
   await assertOrgMember(userId, orgId);
   await SeasonService.assertSeasonExists(seasonId, orgId);
 
-  const songs = await SongRepository.getSongsBySeasonId(seasonId);
+  const songs = await SongRepository.getSongsBySeasonId(seasonId, orgId);
 
   const parsed = songSchema.array().safeParse(songs);
 
@@ -186,10 +158,8 @@ const deleteSong = async (id: string, orgId: string, userId: string) => {
 };
 
 const SongService = {
-  assertSongExists,
   assertSongAccess,
   createSong,
-  getSongById,
   getSongByIdForUser,
   getSongByIdInOrg,
   getSongsBySeasonId,

--- a/apps/assassin/src/features/song/service.ts
+++ b/apps/assassin/src/features/song/service.ts
@@ -16,16 +16,12 @@ const assertSongAccess = async (songId: string, userId: string): Promise<string>
   return orgId;
 };
 
-const getSongByIdForUser = async (id: string, userId: string): Promise<Song | null> => {
-  const orgId = await OrgRepository.getOrgIdBySongId(id);
-  if (!orgId) return null;
-
-  try {
-    await assertOrgMember(userId, orgId);
-  } catch {
-    return null;
-  }
-
+const getSongByIdForUser = async (
+  id: string,
+  orgId: string,
+  userId: string,
+): Promise<Song | null> => {
+  await assertOrgMember(userId, orgId);
   const song = await SongRepository.getSongByIdInOrg(id, orgId);
   if (!song) return null;
 

--- a/apps/assassin/src/features/songLike/actions.ts
+++ b/apps/assassin/src/features/songLike/actions.ts
@@ -3,20 +3,17 @@
 import { revalidateSeasonBoard } from "@libs/cache/seasonBoard";
 import { getCurrentUser } from "@libs/supabase/auth";
 import SongLikeService from "./service";
-import SongRepository from "@features/song/repository";
 
 export const getSongLikedByUserAction = async (songId: string): Promise<string | null> => {
   const user = await getCurrentUser();
   return SongLikeService.getUserLikeIdForSong(songId, user.id);
 };
 
-export const toggleSongLikeAction = async (songId: string): Promise<{ likeId: string | null }> => {
+export const toggleSongLikeAction = async (
+  songId: string,
+): Promise<{ likeId: string | null; orgId: string }> => {
   const user = await getCurrentUser();
   const result = await SongLikeService.toggleLike(songId, user.id);
-  const orgId = await SongRepository.getSongOrgIdById(songId);
-  if (!orgId) {
-    throw new Error(`Song with ID ${songId} does not exist.`);
-  }
-  revalidateSeasonBoard(orgId);
+  revalidateSeasonBoard(result.orgId);
   return result;
 };

--- a/apps/assassin/src/features/songLike/hooks/useRealtimeSongLikeSync.ts
+++ b/apps/assassin/src/features/songLike/hooks/useRealtimeSongLikeSync.ts
@@ -3,6 +3,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { createBrowserSupabaseClient } from "@/libs/supabase/client";
 import { songLikeKeys } from "../queries/keys";
 import { songKeys } from "@features/song/queries/keys";
+import { Song } from "@features/song/schema";
 import { useCurrentUserId } from "@/features/user/hooks/useCurrentUserId";
 import { useOrgId } from "@/components/org/OrgProvider";
 
@@ -16,14 +17,13 @@ export const useRealtimeSongLikeSync = (songId: string) => {
   const queryClient = useQueryClient();
   const supabase = useMemo(() => createBrowserSupabaseClient(), []);
   const orgId = useOrgId();
-
   const userId = useCurrentUserId();
 
   useEffect(() => {
     if (!userId) return;
 
     const likesChannel = supabase
-      .channel(`realtime:song_like:${songId}:${userId}`)
+      .channel(`realtime:song_like:${orgId}:${songId}`)
       .on("postgres_changes", { event: "*", schema: "public", table: "song_like" }, (payload) => {
         const nextLike = payload.new as SongLikeRow | undefined;
         const prevLike = payload.old as SongLikeRow | undefined;
@@ -34,8 +34,19 @@ export const useRealtimeSongLikeSync = (songId: string) => {
         if (affectedSongId && affectedSongId !== songId) return;
         if (affectedUserId && affectedUserId !== userId) return;
 
-        queryClient.invalidateQueries({ queryKey: songLikeKeys.byUser(orgId, songId) });
-        queryClient.invalidateQueries({ queryKey: songKeys.org(orgId) });
+        const isInsert = payload.eventType === "INSERT";
+        const likeId = isInsert ? (nextLike?.id ?? null) : null;
+        const delta = isInsert ? 1 : -1;
+
+        queryClient.setQueryData(songLikeKeys.byUser(orgId, songId), likeId);
+
+        queryClient.setQueryData(songKeys.detail(orgId, songId), (old: Song | null | undefined) =>
+          old ? { ...old, likeCount: old.likeCount + delta } : old,
+        );
+
+        queryClient.setQueriesData<Song[]>({ queryKey: songKeys.lists(orgId) }, (old) =>
+          old?.map((s) => (s.id === songId ? { ...s, likeCount: s.likeCount + delta } : s)),
+        );
       })
       .subscribe();
 

--- a/apps/assassin/src/features/songLike/hooks/useRealtimeSongLikeSync.ts
+++ b/apps/assassin/src/features/songLike/hooks/useRealtimeSongLikeSync.ts
@@ -44,7 +44,7 @@ export const useRealtimeSongLikeSync = (songId: string) => {
           old ? { ...old, likeCount: old.likeCount + delta } : old,
         );
 
-        queryClient.setQueriesData<Song[]>({ queryKey: songKeys.lists(orgId) }, (old) =>
+        queryClient.setQueriesData<Song[]>({ queryKey: songKeys.byOrg(orgId) }, (old) =>
           old?.map((s) => (s.id === songId ? { ...s, likeCount: s.likeCount + delta } : s)),
         );
       })

--- a/apps/assassin/src/features/songLike/hooks/useRealtimeSongLikeSync.ts
+++ b/apps/assassin/src/features/songLike/hooks/useRealtimeSongLikeSync.ts
@@ -32,21 +32,28 @@ export const useRealtimeSongLikeSync = (songId: string) => {
         const affectedUserId = nextLike?.userId ?? prevLike?.userId;
 
         if (affectedSongId && affectedSongId !== songId) return;
-        if (affectedUserId && affectedUserId !== userId) return;
 
         const isInsert = payload.eventType === "INSERT";
         const likeId = isInsert ? (nextLike?.id ?? null) : null;
         const delta = isInsert ? 1 : -1;
 
-        queryClient.setQueryData(songLikeKeys.byUser(orgId, songId), likeId);
-
-        queryClient.setQueryData(songKeys.detail(orgId, songId), (old: Song | null | undefined) =>
-          old ? { ...old, likeCount: old.likeCount + delta } : old,
-        );
-
-        queryClient.setQueriesData<Song[]>({ queryKey: songKeys.byOrg(orgId) }, (old) =>
-          old?.map((s) => (s.id === songId ? { ...s, likeCount: s.likeCount + delta } : s)),
-        );
+        if (affectedUserId === userId) {
+          // 다른 탭에서의 본인 이벤트 — byUser만 동기화 (mutation이 likeCount 처리)
+          queryClient.setQueryData(songLikeKeys.byUser(orgId, songId), likeId);
+        } else if (affectedUserId !== undefined) {
+          // 다른 유저의 이벤트 — likeCount만 업데이트
+          queryClient.setQueryData(songKeys.detail(orgId, songId), (old: Song | null | undefined) =>
+            old ? { ...old, likeCount: old.likeCount + delta } : old,
+          );
+          queryClient.setQueriesData<Song[]>({ queryKey: songKeys.byOrg(orgId) }, (old) =>
+            old?.map((s) => (s.id === songId ? { ...s, likeCount: s.likeCount + delta } : s)),
+          );
+        } else {
+          // userId 미확인 (DELETE + REPLICA IDENTITY FULL 미설정) — 서버에서 재조회
+          queryClient.invalidateQueries({ queryKey: songKeys.detail(orgId, songId) });
+          queryClient.invalidateQueries({ queryKey: songKeys.byOrg(orgId) });
+          queryClient.invalidateQueries({ queryKey: songLikeKeys.byUser(orgId, songId) });
+        }
       })
       .subscribe();
 

--- a/apps/assassin/src/features/songLike/mutations/useToggleLike.ts
+++ b/apps/assassin/src/features/songLike/mutations/useToggleLike.ts
@@ -20,7 +20,7 @@ export const useToggleLike = (songId: string) => {
         old ? { ...old, likeCount: old.likeCount + delta } : old,
       );
 
-      queryClient.setQueriesData<Song[]>({ queryKey: songKeys.lists(orgId) }, (old) =>
+      queryClient.setQueriesData<Song[]>({ queryKey: songKeys.byOrg(orgId) }, (old) =>
         old?.map((s) => (s.id === songId ? { ...s, likeCount: s.likeCount + delta } : s)),
       );
     },

--- a/apps/assassin/src/features/songLike/mutations/useToggleLike.ts
+++ b/apps/assassin/src/features/songLike/mutations/useToggleLike.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toggleSongLikeAction } from "../actions";
 import { songLikeKeys } from "../queries/keys";
 import { songKeys } from "@features/song/queries/keys";
+import { Song } from "@features/song/schema";
 import { useOrgId } from "@/components/org/OrgProvider";
 
 export const useToggleLike = (songId: string) => {
@@ -10,9 +11,18 @@ export const useToggleLike = (songId: string) => {
 
   return useMutation({
     mutationFn: () => toggleSongLikeAction(songId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: songLikeKeys.byUser(orgId, songId) });
-      queryClient.invalidateQueries({ queryKey: songKeys.org(orgId) });
+    onSuccess: (data) => {
+      const delta = data.likeId !== null ? 1 : -1;
+
+      queryClient.setQueryData(songLikeKeys.byUser(orgId, songId), data.likeId);
+
+      queryClient.setQueryData(songKeys.detail(orgId, songId), (old: Song | null | undefined) =>
+        old ? { ...old, likeCount: old.likeCount + delta } : old,
+      );
+
+      queryClient.setQueriesData<Song[]>({ queryKey: songKeys.lists(orgId) }, (old) =>
+        old?.map((s) => (s.id === songId ? { ...s, likeCount: s.likeCount + delta } : s)),
+      );
     },
   });
 };

--- a/apps/assassin/src/features/songLike/repository.ts
+++ b/apps/assassin/src/features/songLike/repository.ts
@@ -14,7 +14,6 @@ async function createLike(songId: string, userId: string, orgId: string, tx?: Tr
     where: { id: songId, season: { orgId }, deletedAt: null },
     select: { id: true },
   });
-
   if (!song) throw new Error("Song not found in org");
 
   return prismaClient.songLike.create({

--- a/apps/assassin/src/features/songLike/repository.ts
+++ b/apps/assassin/src/features/songLike/repository.ts
@@ -1,25 +1,32 @@
 import { TransactionClient } from "@/libs/prisma/types";
 import { prisma } from "@libs/prisma/client";
 
-async function getLikeBySongAndUser(songId: string, userId: string) {
-  return prisma.songLike.findUnique({
-    where: { songId_userId: { songId, userId } },
+async function getLikeBySongAndUser(songId: string, userId: string, orgId: string) {
+  return prisma.songLike.findFirst({
+    where: { songId, userId, song: { season: { orgId }, deletedAt: null } },
   });
 }
 
-async function createLike(songId: string, userId: string, tx?: TransactionClient) {
+async function createLike(songId: string, userId: string, orgId: string, tx?: TransactionClient) {
   const prismaClient = tx || prisma;
+
+  const song = await prismaClient.song.findFirst({
+    where: { id: songId, season: { orgId }, deletedAt: null },
+    select: { id: true },
+  });
+
+  if (!song) throw new Error("Song not found in org");
 
   return prismaClient.songLike.create({
     data: { songId, userId },
   });
 }
 
-async function deleteLike(songId: string, userId: string, tx?: TransactionClient) {
+async function deleteLike(songId: string, userId: string, orgId: string, tx?: TransactionClient) {
   const prismaClient = tx || prisma;
 
-  return prismaClient.songLike.delete({
-    where: { songId_userId: { songId, userId } },
+  return prismaClient.songLike.deleteMany({
+    where: { songId, userId, song: { season: { orgId }, deletedAt: null } },
   });
 }
 

--- a/apps/assassin/src/features/songLike/service.ts
+++ b/apps/assassin/src/features/songLike/service.ts
@@ -3,9 +3,9 @@ import SongLikeRepository from "./repository";
 import { songLikeSchema } from "./schema";
 
 const getUserLikeIdForSong = async (songId: string, userId: string): Promise<string | null> => {
-  await SongService.assertSongAccess(songId, userId);
+  const orgId = await SongService.assertSongAccess(songId, userId);
 
-  const like = await SongLikeRepository.getLikeBySongAndUser(songId, userId);
+  const like = await SongLikeRepository.getLikeBySongAndUser(songId, userId, orgId);
 
   if (!like) {
     return null;
@@ -21,17 +21,20 @@ const getUserLikeIdForSong = async (songId: string, userId: string): Promise<str
   return parsed.data.id;
 };
 
-const toggleLike = async (songId: string, userId: string): Promise<{ likeId: string | null }> => {
-  await SongService.assertSongAccess(songId, userId);
+const toggleLike = async (
+  songId: string,
+  userId: string,
+): Promise<{ likeId: string | null; orgId: string }> => {
+  const orgId = await SongService.assertSongAccess(songId, userId);
 
-  const existing = await SongLikeRepository.getLikeBySongAndUser(songId, userId);
+  const existing = await SongLikeRepository.getLikeBySongAndUser(songId, userId, orgId);
 
   if (existing) {
-    await SongLikeRepository.deleteLike(songId, userId);
-    return { likeId: null };
+    await SongLikeRepository.deleteLike(songId, userId, orgId);
+    return { likeId: null, orgId };
   }
 
-  const created = await SongLikeRepository.createLike(songId, userId);
+  const created = await SongLikeRepository.createLike(songId, userId, orgId);
 
   const parsed = songLikeSchema.safeParse(created);
 
@@ -40,7 +43,7 @@ const toggleLike = async (songId: string, userId: string): Promise<{ likeId: str
     throw new Error("Failed to create like");
   }
 
-  return { likeId: parsed.data.id };
+  return { likeId: parsed.data.id, orgId };
 };
 
 const SongLikeService = {

--- a/apps/assassin/src/features/user/actions.ts
+++ b/apps/assassin/src/features/user/actions.ts
@@ -15,9 +15,9 @@ export const getCurrentUserProfileAction = async () => {
   return await UserService.getProfile(user.id);
 };
 
-export const getProfilesBySongAction = async (songId: string) => {
+export const getProfilesBySongAction = async (songId: string, orgId: string) => {
   const user = await getCurrentUser();
-  return await UserService.getProfilesBySong(songId, user.id);
+  return await UserService.getProfilesBySong(songId, orgId, user.id);
 };
 
 export const updateProfileAction = async (payload: UpdateProfilePayload) => {

--- a/apps/assassin/src/features/user/queries/useProfilesBySong.ts
+++ b/apps/assassin/src/features/user/queries/useProfilesBySong.ts
@@ -8,6 +8,6 @@ export const useProfilesBySong = (songId: string) => {
 
   return useSuspenseQuery({
     queryKey: userKeys.profilesBySong(orgId, songId),
-    queryFn: () => getProfilesBySongAction(songId),
+    queryFn: () => getProfilesBySongAction(songId, orgId),
   });
 };

--- a/apps/assassin/src/features/user/service.ts
+++ b/apps/assassin/src/features/user/service.ts
@@ -1,5 +1,5 @@
-import SongService from "@features/song/service";
 import { assertOrgMember } from "@features/org/service";
+import SongRepository from "@features/song/repository";
 import UserRepository from "./repository";
 import { Profile, profileSchema, updateProfileSchema, UpdateProfilePayload } from "./schema";
 
@@ -13,8 +13,18 @@ const getProfilesByOrg = async (orgId: string, requesterId: string): Promise<Pro
   return parsed.data;
 };
 
-const getProfilesBySong = async (songId: string, requesterId: string): Promise<Profile[]> => {
-  const orgId = await SongService.assertSongAccess(songId, requesterId);
+const getProfilesBySong = async (
+  songId: string,
+  orgId: string,
+  requesterId: string,
+): Promise<Profile[]> => {
+  await assertOrgMember(requesterId, orgId);
+
+  const song = await SongRepository.getSongByIdInOrg(songId, orgId);
+  if (!song) {
+    throw new Error("Song not found");
+  }
+
   return await getProfilesByOrg(orgId, requesterId);
 };
 


### PR DESCRIPTION
## Summary

  - 전 도메인 repository 쿼리에 orgId 스코핑 적용 (WHERE 절)
  - 전 도메인 service에 `assertOrgMember` 가드 및 orgId 전달 통일
  - 뮤테이션 훅 캐시 무효화 키에 orgId 포함, 쿼리 훅 staleTime 통일